### PR TITLE
Add secure backend boundary for Legal Evidence Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,6 @@ It lets visitors load synthetic or local text documents, inspect a visible evide
 ### OpenProof Legal Evidence Lab — stable public route
 
 The browser reference interface is also available through the stable route [docs/legal/](docs/legal/index.html), intended to sit behind the future hostname legal.openproof.net. The repository includes a 25-report synthetic calibration manifest ([scores.json](examples/cnrs-legal-mvp/benchmark/scores.json)); its final human scores are calibration references, not legal findings or ground truth. The raw report archive is not published by default.
+
+
+The deployable backend boundary is documented in [backend/](backend/) and remains disabled until hosted with TLS, authentication, isolated workers, retention controls and a private TruthX adapter.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+.venv
+__pycache__
+.pytest_cache
+*.pyc

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install --no-cache-dir .
+
+ENV OPENPROOF_DATA_DIR=/tmp/openproof-legal-evidence-lab
+EXPOSE 8000
+CMD ["uvicorn", "legal_lab_api.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,35 @@
+# OpenProof Legal Evidence Lab — backend boundary
+
+This directory is the deployable backend boundary for the public browser MVP. It is intentionally separate from the static `docs/` interface and from the private TruthX runtime.
+
+## What it does
+
+- accepts bounded multipart uploads (`txt`, `md`, `json`, `csv`, `xml`, images and optional PDFs);
+- creates a short-lived job and processes it through a bounded in-memory queue;
+- hashes each submitted source and emits an RPO v0.1 core plus a separate analysis ledger;
+- keeps exploratory signals and uncertainty outside the RPO core;
+- removes uploaded source material after artifact creation;
+- purges completed or failed jobs after the configured retention period;
+- exposes an explicit, disabled-by-default TruthX integration boundary.
+
+## Local run
+
+```bash
+cd backend
+python -m venv .venv
+. .venv/bin/activate
+pip install -e '.[test,ocr]'
+PYTHONPATH=src pytest
+openproof-legal-api
+```
+
+The API listens on `127.0.0.1:8000` by default. A production deployment must place it behind TLS, authentication/rate limiting, a persistent queue, an isolated worker pool and an external object store with an explicit deletion policy. The in-memory queue is a runnable MVP boundary, not a production availability guarantee.
+
+## API flow
+
+1. `POST /v1/jobs` with one or more files and an optional context note.
+2. Poll `GET /v1/jobs/{job_id}`.
+3. Read `GET /v1/jobs/{job_id}/rpo` and `/ledger` after completion.
+4. Delete explicitly with `DELETE /v1/jobs/{job_id}`; automatic retention cleanup also runs.
+
+The service does not make legal findings, identify a perpetrator, render a judgment or provide legal advice. Do not submit real personal data to a local development instance without an appropriate privacy and legal framework.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openproof-legal-evidence-api"
+version = "0.1.0"
+description = "Bounded, queue-backed API boundary for OpenProof Legal Evidence Lab."
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115,<1",
+  "python-multipart>=0.0.9,<1",
+  "uvicorn[standard]>=0.30,<1",
+]
+
+[project.optional-dependencies]
+ocr = [
+  "Pillow>=10,<12",
+  "pypdf>=5,<6",
+  "pytesseract>=0.3.13,<1",
+]
+test = ["pytest>=8,<9", "httpx>=0.27,<1"]
+
+[project.scripts]
+openproof-legal-api = "legal_lab_api.app:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/backend/src/legal_lab_api/__init__.py
+++ b/backend/src/legal_lab_api/__init__.py
@@ -1,0 +1,3 @@
+"""OpenProof Legal Evidence Lab backend boundary."""
+
+__version__ = "0.1.0"

--- a/backend/src/legal_lab_api/app.py
+++ b/backend/src/legal_lab_api/app.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile, status
+from fastapi.responses import JSONResponse
+
+from .config import Settings
+from .jobs import Job, JobManager
+from .pipeline import ALLOWED_EXTENSIONS, process_job
+from .truthx import TruthXBoundary
+
+_JOB_ID = re.compile(r"^[a-f0-9]{32}$")
+
+
+def _safe_upload_name(name: str | None) -> str:
+    value = name or "unnamed"
+    if value != Path(value).name or "\\" in value or value in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Invalid filename.")
+    if len(value) > 180 or Path(value).suffix.lower() not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Unsupported file type or filename.")
+    return value
+
+
+def _job_payload(job: Job) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "job_id": job.id,
+        "status": job.status,
+        "created_at": job.created_at.isoformat(),
+        "expires_at": job.expires_at.isoformat(),
+        "status_url": f"/v1/jobs/{job.id}",
+    }
+    if job.status == "completed":
+        payload["artifacts"] = {
+            "rpo": f"/v1/jobs/{job.id}/rpo",
+            "analysis_ledger": f"/v1/jobs/{job.id}/ledger",
+        }
+    if job.error:
+        payload["error"] = "processing_failed"
+    return payload
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    config = settings or Settings()
+    manager = JobManager(config)
+    stop_cleaner = threading.Event()
+
+    def cleanup_loop() -> None:
+        while not stop_cleaner.wait(60):
+            manager.purge_expired()
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI):
+        cleaner = threading.Thread(target=cleanup_loop, name="openproof-cleaner", daemon=True)
+        cleaner.start()
+        try:
+            yield
+        finally:
+            stop_cleaner.set()
+            manager.shutdown()
+
+    app = FastAPI(
+        title="OpenProof Legal Evidence Lab API",
+        version="0.1.0",
+        description="Bounded processing boundary for the browser MVP; not a legal decision service.",
+        lifespan=lifespan,
+    )
+    app.state.manager = manager
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok", "service": "openproof-legal-evidence-lab"}
+
+    @app.post("/v1/jobs", status_code=status.HTTP_202_ACCEPTED)
+    async def create_job(files: list[UploadFile] = File(default=[]), note: str = Form(default="")) -> JSONResponse:
+        if len(files) > config.max_files:
+            raise HTTPException(status_code=413, detail="Too many files.")
+        if not files and not note.strip():
+            raise HTTPException(status_code=400, detail="Provide at least one supported file or a context note.")
+        try:
+            job = manager.create()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=429, detail="The processing queue is full.") from exc
+        total = 0
+        try:
+            for upload in files:
+                filename = _safe_upload_name(upload.filename)
+                target = job.directory / filename
+                if target.exists():
+                    raise HTTPException(status_code=400, detail="Duplicate filenames are not accepted.")
+                size = 0
+                with target.open("wb") as stream:
+                    while True:
+                        chunk = await upload.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        size += len(chunk)
+                        total += len(chunk)
+                        if size > config.max_file_bytes or total > config.max_total_bytes:
+                            raise HTTPException(status_code=413, detail="Upload exceeds configured size limits.")
+                        stream.write(chunk)
+                await upload.close()
+            if note.strip():
+                if len(note.encode("utf-8")) > config.max_file_bytes:
+                    raise HTTPException(status_code=413, detail="Context note exceeds configured size limits.")
+                (job.directory / "context-note.txt").write_text(note, encoding="utf-8")
+        except Exception:
+            manager.delete(job.id)
+            raise
+
+        truthx = TruthXBoundary(enabled=config.truthx_enabled, endpoint=config.truthx_url)
+
+        def processor(current: Job) -> dict[str, Path]:
+            artifacts = process_job(current.id, current.directory, truthx)
+            rpo_path = current.directory / "rpo.json"
+            ledger_path = current.directory / "analysis-ledger.json"
+            rpo_path.write_text(json.dumps(artifacts["rpo"], ensure_ascii=False, indent=2), encoding="utf-8")
+            ledger_path.write_text(json.dumps(artifacts["ledger"], ensure_ascii=False, indent=2), encoding="utf-8")
+            # Do not retain extracted text or uploaded source files after artifact creation.
+            for path in current.directory.iterdir():
+                if path not in {rpo_path, ledger_path}:
+                    if path.is_file():
+                        path.unlink(missing_ok=True)
+            return {"rpo": rpo_path, "ledger": ledger_path}
+
+        manager.submit(job, processor)
+        return JSONResponse(_job_payload(job), status_code=status.HTTP_202_ACCEPTED)
+
+    def require_job(job_id: str) -> Job:
+        if not _JOB_ID.fullmatch(job_id):
+            raise HTTPException(status_code=404, detail="Job not found.")
+        job = manager.get(job_id)
+        if not job or job.status == "deleted":
+            raise HTTPException(status_code=404, detail="Job not found.")
+        return job
+
+    @app.get("/v1/jobs/{job_id}")
+    async def get_job(job_id: str) -> dict[str, Any]:
+        return _job_payload(require_job(job_id))
+
+    @app.get("/v1/jobs/{job_id}/rpo")
+    async def get_rpo(job_id: str) -> JSONResponse:
+        job = require_job(job_id)
+        if job.status != "completed":
+            raise HTTPException(status_code=409, detail="Job is not completed.")
+        return JSONResponse(json.loads(job.artifacts["rpo"].read_text(encoding="utf-8")))
+
+    @app.get("/v1/jobs/{job_id}/ledger")
+    async def get_ledger(job_id: str) -> JSONResponse:
+        job = require_job(job_id)
+        if job.status != "completed":
+            raise HTTPException(status_code=409, detail="Job is not completed.")
+        return JSONResponse(json.loads(job.artifacts["ledger"].read_text(encoding="utf-8")))
+
+    @app.delete("/v1/jobs/{job_id}", status_code=status.HTTP_204_NO_CONTENT)
+    async def delete_job(job_id: str) -> None:
+        require_job(job_id)
+        if not manager.delete(job_id):
+            raise HTTPException(status_code=409, detail="Running jobs cannot be deleted.")
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("legal_lab_api.app:app", host="127.0.0.1", port=8000, reload=False)

--- a/backend/src/legal_lab_api/config.py
+++ b/backend/src/legal_lab_api/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _positive_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime limits. Defaults are deliberately conservative for a public MVP."""
+
+    data_dir: Path = Path(os.getenv("OPENPROOF_DATA_DIR", "/tmp/openproof-legal-evidence-lab"))
+    max_files: int = _positive_int("OPENPROOF_MAX_FILES", 20)
+    max_file_bytes: int = _positive_int("OPENPROOF_MAX_FILE_BYTES", 10 * 1024 * 1024)
+    max_total_bytes: int = _positive_int("OPENPROOF_MAX_TOTAL_BYTES", 50 * 1024 * 1024)
+    max_queue: int = _positive_int("OPENPROOF_MAX_QUEUE", 16)
+    worker_count: int = _positive_int("OPENPROOF_WORKERS", 2)
+    retention_seconds: int = _positive_int("OPENPROOF_RETENTION_SECONDS", 60 * 60)
+    truthx_enabled: bool = os.getenv("OPENPROOF_TRUTHX_ENABLED", "false").lower() == "true"
+    truthx_url: str = os.getenv("OPENPROOF_TRUTHX_URL", "")

--- a/backend/src/legal_lab_api/jobs.py
+++ b/backend/src/legal_lab_api/jobs.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import shutil
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import Settings
+
+
+@dataclass
+class Job:
+    id: str
+    directory: Path
+    created_at: datetime
+    expires_at: datetime
+    status: str = "queued"
+    error: str | None = None
+    artifacts: dict[str, Path] = field(default_factory=dict)
+
+
+class JobManager:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.settings.data_dir.mkdir(parents=True, exist_ok=True)
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.RLock()
+        self._executor = ThreadPoolExecutor(max_workers=settings.worker_count, thread_name_prefix="openproof-job")
+
+    def create(self) -> Job:
+        with self._lock:
+            active = sum(job.status in {"queued", "running"} for job in self._jobs.values())
+            if active >= self.settings.max_queue:
+                raise RuntimeError("The processing queue is full.")
+            now = datetime.now(timezone.utc)
+            job_id = uuid.uuid4().hex
+            directory = self.settings.data_dir / job_id
+            directory.mkdir(mode=0o700)
+            job = Job(job_id, directory, now, now + timedelta(seconds=self.settings.retention_seconds))
+            self._jobs[job_id] = job
+            return job
+
+    def get(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def submit(self, job: Job, processor: Callable[[Job], dict[str, Path]]) -> None:
+        def run() -> None:
+            with self._lock:
+                if job.status == "deleted":
+                    return
+                job.status = "running"
+            try:
+                artifacts = processor(job)
+                with self._lock:
+                    job.artifacts = artifacts
+                    job.status = "completed"
+            except Exception as exc:  # keep details out of the public response
+                with self._lock:
+                    job.error = type(exc).__name__
+                    job.status = "failed"
+
+        self._executor.submit(run)
+
+    def delete(self, job_id: str) -> bool:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job or job.status == "running":
+                return False
+            self._jobs.pop(job_id, None)
+            job.status = "deleted"
+        shutil.rmtree(job.directory, ignore_errors=True)
+        return True
+
+    def purge_expired(self) -> int:
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            expired = [job.id for job in self._jobs.values() if job.expires_at <= now and job.status not in {"queued", "running"}]
+        return sum(self.delete(job_id) for job_id in expired)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        for job_id in list(self._jobs):
+            self.delete(job_id)

--- a/backend/src/legal_lab_api/pipeline.py
+++ b/backend/src/legal_lab_api/pipeline.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .truthx import TruthXBoundary
+
+TEXT_EXTENSIONS = {".txt", ".md", ".json", ".csv", ".xml"}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp"}
+PDF_EXTENSIONS = {".pdf"}
+ALLOWED_EXTENSIONS = TEXT_EXTENSIONS | IMAGE_EXTENSIONS | PDF_EXTENSIONS
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _extract_text(path: Path) -> tuple[str, str, str | None]:
+    suffix = path.suffix.lower()
+    if suffix in TEXT_EXTENSIONS:
+        return path.read_text(encoding="utf-8", errors="replace"), "text", None
+    if suffix in PDF_EXTENSIONS:
+        try:
+            from pypdf import PdfReader  # type: ignore
+        except ImportError:
+            return "", "pdf", "PDF extraction is not installed; install the optional ocr extra."
+        try:
+            text = "\n".join(page.extract_text() or "" for page in PdfReader(str(path)).pages)
+            return text, "pdf_text", None if text.strip() else "No text extracted from PDF."
+        except Exception as exc:  # pragma: no cover - dependency-specific failures
+            return "", "pdf", f"PDF extraction failed: {type(exc).__name__}"
+    if suffix in IMAGE_EXTENSIONS:
+        try:
+            from PIL import Image  # type: ignore
+            import pytesseract  # type: ignore
+        except ImportError:
+            return "", "image_ocr", "OCR is not installed; install the optional ocr extra."
+        try:
+            text = pytesseract.image_to_string(Image.open(path), config="--psm 6").strip()
+            return text, "image_ocr", None if text else "No text detected by OCR."
+        except Exception as exc:  # pragma: no cover - dependency-specific failures
+            return "", "image_ocr", f"OCR failed: {type(exc).__name__}"
+    return "", "unsupported", "Unsupported file extension."
+
+
+def _unique(items: list[str], value: str) -> None:
+    if value not in items:
+        items.append(value)
+
+
+def _analysis(text: str) -> tuple[list[str], list[str], list[str]]:
+    dates = list(dict.fromkeys(re.findall(r"\b(?:20\d{2}-\d{2}-\d{2}|\d{2}/\d{2}/20\d{2})\b", text)))
+    lower = text.lower()
+    signals: list[str] = []
+    if re.search(r"dois répondre|répondre maintenant|answer now|immediately|tout de suite", lower):
+        _unique(signals, "pression temporelle")
+    if re.search(r"inutile|worthless|stupid|idiot|insulte", lower):
+        _unique(signals, "langage dépréciatif")
+    if re.search(r"partagerai|contenu privé|share private|divulguer|disclose", lower):
+        _unique(signals, "menace de divulgation")
+    if re.search(r"retirée|exclusion|exclu|accès sera|access will", lower):
+        _unique(signals, "pression ou exclusion institutionnelle")
+    if re.search(r"nouveau calendrier|confirment|révisé|revised plan|désaccord ordinaire", lower):
+        _unique(signals, "contre-signal : désaccord ordinaire")
+
+    reservations: list[str] = []
+    if len(dates) < 2:
+        _unique(reservations, "peu d’ancrages temporels explicites")
+    if not re.search(r"témoin|witness|journal|log|historique|history|joint|attach", lower):
+        _unique(reservations, "source corroborante non identifiée")
+    if re.search(r"aucun|pas joint|manque|missing|complet", lower):
+        _unique(reservations, "jeu documentaire potentiellement incomplet")
+    return dates, signals, reservations
+
+
+def _canonical_hash(bundle: dict[str, Any]) -> str:
+    unsigned = json.loads(json.dumps(bundle, ensure_ascii=False))
+    unsigned["registry"]["public_hash"] = ""
+    payload = json.dumps(unsigned, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def process_job(job_id: str, work_dir: Path, truthx: TruthXBoundary) -> dict[str, dict[str, Any]]:
+    """Process only the explicitly-created job directory and return two artifacts."""
+    files = sorted(path for path in work_dir.iterdir() if path.is_file() and path.name != "context-note.txt")
+    evidence: list[dict[str, Any]] = []
+    extracted: list[str] = []
+    errors: list[dict[str, str]] = []
+    for path in files:
+        digest = sha256_file(path)
+        text, extractor, error = _extract_text(path)
+        if text.strip():
+            extracted.append(f"[SOURCE: {path.name}]\n{text.strip()}")
+        if error:
+            errors.append({"filename": path.name, "error": error})
+        evidence.append({
+            "id": f"e-{len(evidence) + 1:03d}",
+            "type": "document",
+            "description": f"Locally submitted source {path.name}.",
+            "filename": path.name,
+            "extractor": extractor,
+            "sha256": digest,
+        })
+
+    context_path = work_dir / "context-note.txt"
+    context = context_path.read_text(encoding="utf-8", errors="replace") if context_path.exists() else ""
+    combined = "\n\n---\n\n".join(extracted + (["[CONTEXT NOTE]\n" + context] if context.strip() else []))
+    dates, signals, reservations = _analysis(combined)
+    created_at = datetime.now(timezone.utc).isoformat()
+    source_set_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+    bundle: dict[str, Any] = {
+        "rpo_version": "0.1",
+        "type": "evidence_bundle",
+        "bundle_id": job_id,
+        "created_at": created_at,
+        "issuer": {"name": "OpenProof Legal Evidence Lab", "id": "openproof-legal-evidence-lab", "role": "probative infrastructure"},
+        "subject": {"name": "Submitted evidence review", "id": f"job-{job_id}", "role": "demo subject"},
+        "evidence": evidence,
+        "narrative": {
+            "summary": "Submitted sources structured by the OpenProof public backend boundary. Exploratory signals remain outside the RPO core.",
+            "pdf_hash": f"sha256:{source_set_hash}",
+            "timeline_ref": f"timeline:{job_id}",
+        },
+        "registry": {"registry_id": "openproof-public-backend", "entry_id": job_id, "public_hash": ""},
+    }
+    bundle["registry"]["public_hash"] = _canonical_hash(bundle)
+    ledger: dict[str, Any] = {
+        "format": "openproof-analysis-ledger-draft",
+        "version": "0.1",
+        "generated_at": created_at,
+        "boundary": "queued-backend-mvp",
+        "rpo_bundle_id": job_id,
+        "sources": evidence,
+        "timeline": dates,
+        "signals": signals,
+        "reservations": reservations,
+        "extraction_errors": errors,
+        "interpretation": {
+            "status": "reviewable" if signals and "contre-signal : désaccord ordinaire" not in signals else "exploratory",
+            "note": "Deterministic exploration only; this service does not produce legal findings, advice or adjudication.",
+        },
+    }
+    ledger["truthx_boundary"] = truthx.enrich(ledger)
+    return {"rpo": bundle, "ledger": ledger}

--- a/backend/src/legal_lab_api/truthx.py
+++ b/backend/src/legal_lab_api/truthx.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TruthXBoundary:
+    """Explicit integration boundary; disabled unless an operator enables it."""
+
+    enabled: bool = False
+    endpoint: str = ""
+
+    def enrich(self, ledger: dict[str, Any]) -> dict[str, Any]:
+        if not self.enabled:
+            return {
+                "status": "disabled",
+                "note": "TruthX execution is not enabled in the public backend boundary.",
+            }
+        if not self.endpoint:
+            return {
+                "status": "blocked",
+                "note": "TruthX was enabled without a configured private endpoint.",
+            }
+        # The production adapter belongs behind an authenticated service boundary.
+        # It is intentionally not implemented as an implicit outbound LLM call here.
+        return {
+            "status": "configured",
+            "note": "A private TruthX adapter must add an auditable, redacted result here. The endpoint is never returned to clients.",
+        }

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from legal_lab_api.config import Settings
+from legal_lab_api.jobs import JobManager
+from legal_lab_api.pipeline import process_job
+from legal_lab_api.truthx import TruthXBoundary
+
+
+def test_pipeline_builds_rpo_and_keeps_signals_out_of_core(tmp_path: Path) -> None:
+    work = tmp_path / "job"
+    work.mkdir()
+    (work / "messages.txt").write_text(
+        "2026-01-12 — Personne B écrit : Tu dois répondre maintenant. Tu es inutile.\n"
+        "2026-01-15 — Un témoin note la situation.",
+        encoding="utf-8",
+    )
+    artifacts = process_job("a" * 32, work, TruthXBoundary())
+    rpo, ledger = artifacts["rpo"], artifacts["ledger"]
+    assert rpo["rpo_version"] == "0.1"
+    assert len(rpo["registry"]["public_hash"]) == 64
+    assert "signals" not in rpo
+    assert "pression temporelle" in ledger["signals"]
+    assert ledger["truthx_boundary"]["status"] == "disabled"
+
+
+def test_job_manager_purges_only_expired_completed_job(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path, retention_seconds=1)
+    manager = JobManager(settings)
+    job = manager.create()
+    job.status = "completed"
+    job.expires_at = job.created_at
+    assert manager.purge_expired() == 1
+    assert not job.directory.exists()
+    manager.shutdown()

--- a/docs/legal-evidence-lab-deployment.md
+++ b/docs/legal-evidence-lab-deployment.md
@@ -10,4 +10,6 @@ The current RPO repository contains the public static boundary and a stable rout
 
 The route is deliberately static and safe to publish before the secured backend is connected. It provides the browser-local simulator, multi-document text intake, visible pipeline trace, benchmark calibration panel and RPO v0.1 export.
 
-The full backend remains a separate deployment layer for PDF/OCR extraction, queued jobs, isolated processing, automatic deletion and TruthX Engine execution. No secret, model credential or private runtime is stored in this repository.
+The full backend boundary is now documented in `backend/`. It accepts bounded uploads, queues short-lived jobs, extracts text where optional dependencies are installed, emits an RPO plus a separate analysis ledger, removes source files after artifact creation and purges expired jobs. No secret, model credential or private runtime is stored in this repository.
+
+The included queue is a runnable MVP boundary. Before public production use, it still needs TLS, authentication, rate limiting, durable queueing, isolated workers, observability, a tested retention policy and a private TruthX adapter. The browser route remains safe to publish without enabling this backend.


### PR DESCRIPTION
## OpenProof Legal Evidence Lab backend boundary

Adds a runnable, bounded backend layer under `backend/`:

- FastAPI job API with size and extension limits;
- short-lived in-memory queue and worker pool;
- per-job directories with restrictive permissions;
- text extraction plus optional PDF/OCR adapters;
- deterministic RPO v0.1 core and separate analysis ledger;
- source-file removal after artifact creation and retention cleanup;
- explicit disabled-by-default TruthX boundary;
- Dockerfile, package metadata and smoke tests.

The raw student archive and private runtime are not copied into the public repository. Production still requires TLS, auth/rate limiting, durable queueing, isolated workers, observability and a private TruthX adapter.

Local validation passed: Python compilation, RPO/hash/ledger processing smoke test, retention purge smoke test and benchmark JSON validation. Full pytest/API integration requires installing the declared backend dependencies in CI or a deployment environment.