### PR TITLE
Align RPO with OpenProof brand system

### DIFF
--- a/docs/assets/openproof-icon.svg
+++ b/docs/assets/openproof-icon.svg
@@ -1,15 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="OpenProof">
-  <defs>
-    <radialGradient id="bg" cx="42%" cy="35%" r="70%"><stop offset="0" stop-color="#fffdf7"/><stop offset="1" stop-color="#eee4d1"/></radialGradient>
-    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#fff1b4"/><stop offset=".38" stop-color="#b98528"/><stop offset=".7" stop-color="#f3d98a"/><stop offset="1" stop-color="#7c5215"/></linearGradient>
-    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%"><feDropShadow dx="0" dy="8" stdDeviation="8" flood-color="#5d3d0e" flood-opacity=".32"/></filter>
-  </defs>
-  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
-  <circle cx="256" cy="256" r="205" fill="none" stroke="url(#gold)" stroke-width="18" filter="url(#shadow)"/>
-  <g fill="none" stroke="url(#gold)" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" filter="url(#shadow)">
-    <path d="M256 104 182 179q74 51 148 0z"/>
-    <path d="M256 104v304"/>
-    <circle cx="256" cy="292" r="72"/>
-    <path d="M184 292h144M256 220v144"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="OpenProof">
+  <g fill="none" stroke="#e1c38a" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="50" cy="50" r="45.5" stroke-width="2.15" opacity=".92"/>
+    <path d="M50 21V79" stroke-width="3.15"/>
+    <path d="M50 21 35.5 35.5Q50 47 64.5 35.5L50 21Z" stroke-width="3.15"/>
+    <circle cx="50" cy="56.5" r="17.5" stroke-width="3.15"/>
+    <path d="M32.5 56.5H67.5M50 39V74" stroke-width="3.15"/>
   </g>
 </svg>

--- a/docs/assets/openproof-v2.css
+++ b/docs/assets/openproof-v2.css
@@ -137,63 +137,152 @@
 @media(max-width:980px){.summary-grid,.method-grid{grid-template-columns:repeat(2,1fr)}.summary-grid article:nth-child(2),.method-grid article:nth-child(2){border-right:0}.inspection-grid,.verify-grid{grid-template-columns:1fr}}
 @media(max-width:720px){.sub-hero{min-height:auto;padding:82px 0 65px}.sub-hero h1{font-size:2.65rem}.object-summary,.object-inspection,.verify-workspace,.verify-method{padding:65px 0}.summary-grid,.method-grid{grid-template-columns:1fr}.summary-grid article,.method-grid article{border-right:0;border-bottom:1px solid var(--line)}.inspection-grid{gap:34px}.code-panel pre,#rpoInput{min-height:420px;height:420px}}
 
-/* Shared TruthX / OpenProof brand alignment */
+/* OpenProof 2026 — canonical brand system shared with openproof.net */
 :root{
-  --bg:#050809;
-  --surface:#0a0f11;
-  --panel:#0d1214;
-  --ink:#eee9dc;
-  --soft:#c9c3b6;
-  --muted:#8c9292;
-  --gold:#d1aa5c;
-  --pale:#e1c17b;
-  --orange:#b66c45;
-  --green:#1c7664;
-  --amber:#d1aa5c;
-  --line:#e6ddc624;
+  --bg:#050709;
+  --surface:#090d12;
+  --panel:#0d1319;
+  --ink:#f1ede4;
+  --soft:#9da6aa;
+  --muted:#70797d;
+  --gold:#c49a58;
+  --pale:#e1c38a;
+  --orange:#9a6f5b;
+  --green:#62b99c;
+  --amber:#c49a58;
+  --line:rgba(214,194,139,.17);
+  --max:1240px;
   --radius:0;
 }
 body{
-  background:radial-gradient(1100px 550px at 20% -10%,rgba(209,170,92,.11),transparent 60%),linear-gradient(180deg,var(--bg),#020405);
+  background:radial-gradient(900px 680px at 82% 25%,rgba(175,133,72,.10),rgba(43,53,64,.08) 28%,transparent 67%),linear-gradient(180deg,var(--bg),#020406);
 }
-.nav{background:rgba(5,8,9,.92)}
-.navin{min-height:86px}
-.menu,.heroCard,.card,.choice a,.field,.table,.result{border-radius:0}
-.rail{top:104px}
-.rail button.active{background:linear-gradient(90deg,rgba(209,170,92,.09),transparent)}
-.btn{border-radius:0;background:#0a0f11}
-.btn.primary{background:var(--gold);border-color:var(--gold);color:#050809}
-.cosmos::after{background:radial-gradient(circle,rgba(209,170,92,.11),rgba(225,193,123,.035) 42%,transparent 68%)}
-.rpo-home,.rpo-subpage{background:#050809}
-.rpo-home .menu{border-radius:0}
+.rpo-home,.rpo-subpage{background:#050709;color:var(--ink)}
+.menu,.heroCard,.card,.choice a,.field,.table,.result,.btn{border-radius:0}
+.rail{top:110px}
+.rail button.active{background:linear-gradient(90deg,rgba(196,154,88,.10),transparent)}
+
+/* Header: same lockup, rhythm and edge-to-edge geometry as OpenProof. */
+.nav{position:relative;top:auto;background:transparent;backdrop-filter:none;border-bottom:0}
+.navin,
+.rpo-home .navin{
+  width:auto;
+  min-height:92px;
+  margin:0 4.5vw;
+  padding:0;
+  border-bottom:1px solid rgba(214,194,139,.17);
+}
+.brand-lockup{gap:15px}
+.brand-lockup img{
+  width:42px;
+  height:42px;
+  padding:4px;
+  border-radius:0;
+  background:radial-gradient(circle,rgba(199,169,107,.09) 0,transparent 68%);
+  filter:drop-shadow(0 0 9px rgba(195,156,81,.27));
+}
+.brand-lockup strong{font:600 15px/1 Orbitron,Montserrat,sans-serif;letter-spacing:4.6px;color:var(--ink)}
+.brand-lockup small{margin-top:7px;color:#7f898d;font:500 7px/1.2 Montserrat,sans-serif;letter-spacing:2.2px}
+.rpo-home .links{gap:34px}
+.rpo-home .links a{color:#9ca3a4;font:700 8px/1.2 Montserrat,sans-serif;letter-spacing:1.6px}
+.rpo-home .links a:hover,.rpo-home .links a[aria-current=page]{color:var(--pale)}
 .rpo-home .links .external-link{
-  color:#050809;
-  background:linear-gradient(90deg,var(--gold),var(--pale));
-  border:1px solid rgba(225,193,123,.55);
-  padding:11px 16px;
+  color:#080a0c;
+  background:#c7a460;
+  border:1px solid #c5a460;
+  padding:13px 17px;
 }
-.language a{
-  border:0;
-  background:none;
-  color:var(--muted);
-  font:600 .68rem Montserrat,sans-serif;
-  padding:6px 2px;
-  text-decoration:none;
-}
-.language a[aria-current=page]{color:var(--pale)}
+.rpo-home .links .external-link:hover{color:#080a0c;background:#e0c183;border-color:#e0c183}
+.language{gap:7px;color:rgba(208,178,125,.42);font:600 9px/1 Orbitron,sans-serif;letter-spacing:1px}
+.language a{border:0;background:none;color:rgba(220,224,218,.48);font:inherit;padding:8px 2px;text-decoration:none}
+.language a:hover,.language a[aria-current=page]{color:#d9b36f;text-shadow:0 0 15px rgba(217,179,111,.34)}
 .language button{display:none}
-.rpo-hero{min-height:calc(100vh - 86px);padding:68px 0}
-.rpo-copy h1{font-size:clamp(2.55rem,5vw,4.75rem);line-height:1.04}
-.rpo-home .btn{border-radius:0}
-.rpo-home .btn.primary{background:linear-gradient(90deg,var(--gold),var(--pale));border-color:rgba(225,193,123,.58);color:#050809}
-.orbit-c{border-color:rgba(225,193,123,.20)}
-.path-grid>a{background:linear-gradient(180deg,rgba(13,18,20,.84),rgba(5,8,9,.92))}
-.sub-hero h1{font-size:clamp(2.7rem,5.8vw,5rem);line-height:1.04;letter-spacing:-.03em}
+
+/* Spatial field: stars and broad orbital arcs, without the competing square grid. */
+.cosmos::before{
+  background:
+    radial-gradient(ellipse 78% 48% at 100% 46%,transparent 0 66.5%,rgba(197,176,125,.15) 66.7% 66.85%,transparent 67.05%),
+    radial-gradient(ellipse 91% 57% at 100% 46%,transparent 0 69%,rgba(197,176,125,.11) 69.2% 69.32%,transparent 69.5%),
+    radial-gradient(ellipse 106% 67% at 100% 46%,transparent 0 71%,rgba(197,176,125,.08) 71.2% 71.3%,transparent 71.5%);
+  background-size:auto;
+  mask-image:none;
+}
+.cosmos::after{width:720px;height:720px;right:-90px;top:40px;background:radial-gradient(circle,rgba(175,133,72,.09),rgba(43,53,64,.14) 25%,transparent 67%);filter:blur(6px)}
+
+/* First viewport: exact OpenProof proportions and typographic hierarchy. */
+.rpo-hero{min-height:790px;padding:0;align-items:stretch}
+.rpo-hero-grid{
+  width:100%;
+  min-height:790px;
+  margin:0;
+  padding:92px 6vw 112px;
+  grid-template-columns:minmax(550px,1fr) minmax(520px,.82fr);
+  gap:4vw;
+}
+.eyebrow,.section-index{color:var(--gold);font-size:7px;letter-spacing:2.2px}
+.rpo-copy h1{
+  max-width:820px;
+  margin:23px 0 31px;
+  color:#ece8df;
+  font:500 clamp(51px,5.2vw,78px)/.98 Orbitron,Montserrat,sans-serif;
+  letter-spacing:-.035em;
+  text-transform:uppercase;
+  text-shadow:0 4px 35px #000;
+}
+.rpo-copy h1 span{color:inherit}
+.rpo-lead{max-width:630px;color:#9ca4a5;font-size:14px;line-height:1.85;letter-spacing:.15px}
+.rpo-actions{margin-top:38px;gap:28px}
+.rpo-home .btn{min-height:48px;padding:15px 21px;color:#aeb4b4;background:transparent;border:1px solid #596064;font:700 8px/1.2 Montserrat,sans-serif;letter-spacing:1.35px}
+.rpo-home .btn:hover{border-color:#dec083;color:#dec083}
+.rpo-home .btn.primary{background:linear-gradient(110deg,#ad8747,#dfc17e);border-color:#d0b06b;color:#0a0c0e}
+.rpo-home .btn.primary:hover{background:linear-gradient(110deg,#c49d59,#eed397);color:#0a0c0e}
+.version-line{margin-top:43px;padding-top:20px;border-top:1px solid rgba(105,113,118,.27);color:#70797c;font-size:7px;letter-spacing:1.25px}
+.rpo-object{max-width:570px;min-height:570px}
+.rpo-object::before{inset:13%;background:radial-gradient(circle,rgba(214,179,106,.09),rgba(100,117,128,.05) 30%,transparent 68%);filter:blur(2px)}
+.orbit-a{width:53%;height:53%;border-color:rgba(172,154,112,.26)}
+.orbit-b{width:76%;height:76%;border-style:solid;border-color:rgba(172,154,112,.20)}
+.orbit-c{width:97%;height:97%;border-color:rgba(133,150,156,.14)}
+.rpo-core{width:170px;height:170px;background:radial-gradient(circle at 48% 42%,#283038,#0a0e12 63%);border-color:#d8bc7b;box-shadow:inset 0 0 45px rgba(210,174,96,.15),0 0 70px rgba(177,140,70,.12),0 0 0 12px rgba(185,155,92,.04)}
+.rpo-core img{width:38px;height:38px;margin-bottom:5px}
+.rpo-core strong{color:#e2c98e}
+.rpo-signal{color:#70797d;font-size:7px;letter-spacing:1.35px}
+.rpo-signal i{width:5px;height:5px;background:#c7a65f;box-shadow:0 0 10px #d5af60}
+
+/* Shared lower-page components. */
+.rpo-definition,.rpo-anatomy,.rpo-paths{border-color:var(--line);background:#080b0f}
+.rpo-anatomy{background:#0d1217}
+.rpo-home section h2{color:#ece8df;font-family:Montserrat,"Helvetica Neue",Arial,sans-serif;font-weight:500}
+.definition-copy>p,.definition-copy .boundary{color:#9da6aa}
+.path-grid>a{border-color:var(--line);background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96))}
+.path-grid>a:hover{border-color:rgba(196,154,88,.52);background:#121820}
+.architecture-line{background:#0d1217;border-color:var(--line)}
+.footer{background:#040608;border-color:rgba(185,154,90,.19)}
+
+/* The technical pages use the same header and spatial language. */
+.sub-hero{min-height:690px;padding:100px 6vw 90px}
+.sub-hero>.wrap{width:100%;max-width:none}
+.sub-hero h1{max-width:1040px;color:#ece8df;font:500 clamp(51px,5.2vw,78px)/.98 Orbitron,Montserrat,sans-serif;letter-spacing:-.035em;text-transform:uppercase}
+
+@media(max-width:1050px){
+  .rpo-hero-grid{grid-template-columns:1fr;padding-top:72px}
+  .rpo-object{width:min(680px,100%);min-height:620px;margin:-35px auto 0}
+}
+@media(max-width:980px){
+  .rpo-home .navin{grid-template-columns:auto 1fr auto}
+  .rpo-home .links{justify-content:flex-start}
+}
 @media(max-width:880px){
-  .links{top:86px;background:#070b0c;border-radius:0}
+  .links{top:92px;background:#070b0c;border-radius:0}
   .rpo-home .links .external-link{display:inline-flex}
 }
 @media(max-width:720px){
-  .rpo-copy h1{font-size:2.45rem}
-  .sub-hero h1{font-size:2.5rem}
+  .navin,.rpo-home .navin{margin:0 20px;grid-template-columns:1fr auto auto;gap:10px}
+  .brand-lockup strong{font-size:12px;letter-spacing:3px}
+  .brand-lockup small{display:none}
+  .rpo-hero{min-height:auto}
+  .rpo-hero-grid{min-height:auto;padding:65px 22px 80px;display:block}
+  .rpo-copy h1{font-size:43px;letter-spacing:-.035em}
+  .rpo-object{min-height:450px;width:124%;margin:-5px -12% -20px;transform:scale(.83)}
+  .sub-hero{min-height:auto;padding:72px 22px 65px}
+  .sub-hero h1{font-size:43px}
 }

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -45,11 +45,11 @@
   "inLanguage": "en"
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>
@@ -58,7 +58,7 @@
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>

--- a/docs/fr/examples.html
+++ b/docs/fr/examples.html
@@ -45,11 +45,11 @@
   "inLanguage": "fr"
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>
@@ -58,7 +58,7 @@
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/fr/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -11,7 +11,7 @@
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html">
 <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/gersende-de-parcey.html">
 <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/gersende-de-parcey.html">
-<link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+<link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <meta property="og:type" content="profile">
   <meta property="og:title" content="Gersende de Parcey">
   <meta property="og:description" content="Gersende de Parcey, fondatrice d’OpenProof et créatrice de TruthX Engine : vingt ans de reconstruction de la réalité organisationnelle devenus une infrastructure probatoire.">
@@ -24,7 +24,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
   <script type="application/ld+json">
   {
   "@context": "https://schema.org",
@@ -129,7 +129,7 @@
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/fr/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -59,12 +59,12 @@
   ]
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>
@@ -74,7 +74,7 @@
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/fr/" aria-current="page">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
@@ -115,7 +115,7 @@
           <div class="rpo-orbit orbit-b"></div>
           <div class="rpo-orbit orbit-c"></div>
           <div class="rpo-core">
-            <img src="/assets/openproof-icon.svg" alt="">
+            <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
             <strong>RPO</strong>
             <span>REGISTERED<br>PROBATIVE OBJECT</span>
           </div>

--- a/docs/fr/tests.html
+++ b/docs/fr/tests.html
@@ -39,11 +39,11 @@
   "inLanguage": "fr"
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>
@@ -52,7 +52,7 @@
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/fr/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -11,7 +11,7 @@
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html">
 <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/gersende-de-parcey.html">
 <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/gersende-de-parcey.html">
-<link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+<link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <meta property="og:type" content="profile">
   <meta property="og:title" content="Gersende de Parcey">
   <meta property="og:description" content="Gersende de Parcey, founder of OpenProof and creator of TruthX Engine: twenty years of organizational reality reconstruction transformed into probative infrastructure.">
@@ -24,7 +24,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
   <script type="application/ld+json">
   {
   "@context": "https://schema.org",
@@ -129,7 +129,7 @@
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,12 +59,12 @@
   ]
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>
@@ -74,7 +74,7 @@
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/" aria-current="page">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>
@@ -115,7 +115,7 @@
           <div class="rpo-orbit orbit-b"></div>
           <div class="rpo-orbit orbit-c"></div>
           <div class="rpo-core">
-            <img src="/assets/openproof-icon.svg" alt="">
+            <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
             <strong>RPO</strong>
             <span>REGISTERED<br>PROBATIVE OBJECT</span>
           </div>

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -39,11 +39,11 @@
   "inLanguage": "en"
 }
   </script>
-  <link rel="icon" href="/assets/openproof-icon.svg" type="image/svg+xml">
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>
@@ -52,7 +52,7 @@
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
       <a class="brand brand-lockup" href="/">
-        <img src="/assets/openproof-icon.svg" alt="" width="38" height="38">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
       <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>


### PR DESCRIPTION
## What changed

- replaces the legacy white-backed RPO emblem with the canonical OpenProof sigil
- applies the exact OpenProof 2026 palette, header geometry, typography, buttons and spatial field
- aligns the homepage and all technical/founder pages in English and French
- versions the shared visual assets to bypass stale browser caches

## Why

The previous pass recolored the RPO site but retained its older visual system, so `rpo.openproof.net` still appeared to belong to a different brand than `openproof.net`.

## Validation

- HTML, canonical, hreflang and local asset checks pass for all 8 bilingual pages
- JavaScript syntax check passes
- CSS braces and whitespace diff checks pass
- existing RPO data tests remain unchanged (the repository still contains pre-existing placeholder/dependency failures unrelated to this visual change)