### PR TITLE
Restore founder public signals and RPO typography

### DIFF
--- a/docs/assets/openproof-v2.css
+++ b/docs/assets/openproof-v2.css
@@ -251,12 +251,25 @@ body{
 /* Shared lower-page components. */
 .rpo-definition,.rpo-anatomy,.rpo-paths{border-color:var(--line);background:#080b0f}
 .rpo-anatomy{background:#0d1217}
-.rpo-home section h2{color:#ece8df;font-family:Montserrat,"Helvetica Neue",Arial,sans-serif;font-weight:500}
+.rpo-home section h2{color:#ece8df;font-family:Orbitron,Montserrat,sans-serif;font-weight:500}
 .definition-copy>p,.definition-copy .boundary{color:#9da6aa}
 .path-grid>a{border-color:var(--line);background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96))}
 .path-grid>a:hover{border-color:rgba(196,154,88,.52);background:#121820}
 .architecture-line{background:#0d1217;border-color:var(--line)}
 .footer{background:#040608;border-color:rgba(185,154,90,.19)}
+
+/* Founder page: public evidence signals validated alongside the product architecture. */
+.founder-proof{padding:105px 0;background:#080b0f;border-bottom:1px solid var(--line)}
+.founder-proof h2{max-width:950px;margin:16px 0 22px;font-size:clamp(2rem,4vw,4rem);line-height:1.12;letter-spacing:-.025em}
+.founder-proof-intro{max-width:850px;margin:0 0 52px;color:var(--soft);font-size:1rem;line-height:1.85}
+.founder-proof-grid{display:grid;grid-template-columns:repeat(3,1fr);border-block:1px solid var(--line)}
+.founder-proof-card{display:flex;min-height:300px;flex-direction:column;padding:34px 30px 30px;border-right:1px solid var(--line)}
+.founder-proof-card:last-child{border-right:0}
+.founder-proof-number{color:var(--gold);font:600 .62rem Orbitron,sans-serif;letter-spacing:.13em}
+.founder-proof-card h3{margin:30px 0 17px;color:var(--pale);font:600 1rem/1.45 Orbitron,Montserrat,sans-serif;letter-spacing:.035em}
+.founder-proof-card p{margin:0 0 28px;color:var(--muted);font-size:.9rem;line-height:1.75}
+.founder-proof-card a{align-self:flex-start;margin-top:auto;padding-bottom:7px;border-bottom:1px solid rgba(225,195,138,.55);color:var(--pale);font:600 .58rem/1.45 Orbitron,Montserrat,sans-serif;letter-spacing:.1em;text-decoration:none}
+.founder-proof-card a:hover{color:#f0d59a;border-color:#f0d59a}
 
 /* The technical pages use the same header and spatial language. */
 .sub-hero{min-height:690px;padding:100px 6vw 90px}
@@ -270,6 +283,9 @@ body{
 @media(max-width:980px){
   .rpo-home .navin{grid-template-columns:auto 1fr auto}
   .rpo-home .links{justify-content:flex-start}
+  .founder-proof-grid{grid-template-columns:1fr}
+  .founder-proof-card{min-height:auto;border-right:0;border-bottom:1px solid var(--line)}
+  .founder-proof-card:last-child{border-bottom:0}
 }
 @media(max-width:880px){
   .links{top:92px;background:#070b0c;border-radius:0}
@@ -285,4 +301,6 @@ body{
   .rpo-object{min-height:450px;width:124%;margin:-5px -12% -20px;transform:scale(.83)}
   .sub-hero{min-height:auto;padding:72px 22px 65px}
   .sub-hero h1{font-size:43px}
+  .founder-proof{padding:75px 0}
+  .founder-proof-intro{margin-bottom:38px}
 }

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>

--- a/docs/fr/examples.html
+++ b/docs/fr/examples.html
@@ -49,7 +49,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -24,7 +24,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
   <script type="application/ld+json">
   {
   "@context": "https://schema.org",
@@ -262,6 +262,34 @@
         </div>
         <p class="architecture-definition"><strong>OpenProof est l’infrastructure probatoire. TruthX Engine est le moteur de structuration déterministe qui l’alimente. Le RPO est l’objet probatoire enregistré qu’il produit.</strong></p>
         </div>
+    </section>
+
+    <section class="founder-proof">
+      <div class="wrap">
+        <p class="section-index">REPÈRES PUBLICS</p>
+        <h2>De l’origine scientifique à la vérification autonome.</h2>
+        <p class="founder-proof-intro">Les modèles produisent des propositions. TruthX contrôle ce qui peut devenir un élément probatoire.</p>
+        <div class="founder-proof-grid">
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">01</span>
+            <h3>Collaboration de recherche GREYC/CNRS</h3>
+            <p>Avec Gaël Dias, professeur en traitement automatique du langage à l’Université de Caen Normandie et directeur adjoint du GREYC. Un prototype de recherche devenu moteur de vérification en 14 modules, sous contrôle humain.</p>
+            <a href="https://dias.users.greyc.fr/about.html">PROFIL SCIENTIFIQUE ↗</a>
+          </article>
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">02</span>
+            <h3>RPO public</h3>
+            <p>La spécification RPO v0.1 formalise un objet probatoire déterministe. Sources, transformations, réserves et empreinte d’intégrité restent structurées, auditables et reproductibles.</p>
+            <a href="/fr/">EXPLORER LA SPÉCIFICATION ↗</a>
+          </article>
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">03</span>
+            <h3>Provenance vérifiable</h3>
+            <p>Chaque source conserve son identifiant, ses transformations et ses réserves. L’empreinte SHA-256 peut être reproduite localement, sans transmettre l’objet à OpenProof.</p>
+            <a href="/fr/tests.html">VÉRIFIER INDÉPENDAMMENT ↗</a>
+          </article>
+        </div>
+      </div>
     </section>
 
     <section class="doctrine">

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -64,7 +64,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>

--- a/docs/fr/tests.html
+++ b/docs/fr/tests.html
@@ -43,7 +43,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="fr_FR">
 <meta property="og:locale:alternate" content="en_US">
 </head>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -24,7 +24,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
   <script type="application/ld+json">
   {
   "@context": "https://schema.org",
@@ -261,6 +261,34 @@
           </article>
         </div>
         <p class="architecture-definition"><strong>OpenProof is the probative infrastructure. TruthX Engine is the deterministic structuring engine powering it. RPO is the Registered Probative Object it produces.</strong></p>
+      </div>
+    </section>
+
+    <section class="founder-proof">
+      <div class="wrap">
+        <p class="section-index">PUBLIC SIGNALS</p>
+        <h2>From scientific origin to independent verification.</h2>
+        <p class="founder-proof-intro">Models generate proposals. TruthX governs what may become evidence.</p>
+        <div class="founder-proof-grid">
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">01</span>
+            <h3>GREYC/CNRS research collaboration</h3>
+            <p>With Gaël Dias, Professor of Natural Language Processing at Université de Caen Normandie and Deputy Director of GREYC. A research prototype transformed into a 14-module verification engine, under human control.</p>
+            <a href="https://dias.users.greyc.fr/about.html">SCIENTIFIC PROFILE ↗</a>
+          </article>
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">02</span>
+            <h3>Public RPO</h3>
+            <p>The RPO v0.1 specification formalises a deterministic probative object. Sources, transformations, reservations and the integrity hash remain structured, auditable and reproducible.</p>
+            <a href="/">EXPLORE THE SPECIFICATION ↗</a>
+          </article>
+          <article class="founder-proof-card">
+            <span class="founder-proof-number">03</span>
+            <h3>Verifiable provenance</h3>
+            <p>Each source retains its identifier, transformations and reservations. The SHA-256 hash can be reproduced locally, without transmitting the object to OpenProof.</p>
+            <a href="/tests.html">VERIFY INDEPENDENTLY ↗</a>
+          </article>
+        </div>
       </div>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,7 +64,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -43,7 +43,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="fr_FR">
 </head>


### PR DESCRIPTION
## What changed

- restores the approved public-signals section on the English and French founder pages
- adds the three balanced proof cards: GREYC/CNRS research collaboration, public RPO, and verifiable provenance
- links each card to one primary public proof surface
- restores Orbitron for structural RPO section headings while retaining Montserrat for body copy
- versions the shared stylesheet across all eight bilingual public pages

## Why

The latest founder-page content had been validated in conversation but never committed to GitHub. A late CSS override also forced large section headings into Montserrat, making the RPO typographically inconsistent with OpenProof and TruthX.

## Validation

- `git diff --check` passes
- English and French founder sections occur exactly once
- canonical and hreflang architecture preserved
- all five public destination links return HTTP 200
- responsive grid collapses from three columns to one below 980px
- JavaScript syntax check passes