### PR TITLE
Justify founder editorial copy

### DIFF
--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -1225,3 +1225,19 @@
     transform: none !important;
   }
 }
+
+/* Editorial prose — justified where the measure is wide enough to stay elegant. */
+@media (min-width: 921px) {
+  .founder-page .founder-hero-lead,
+  .founder-page .founder-section-lead,
+  .founder-page .founder-origin-event p,
+  .founder-page .founder-method-copy p,
+  .founder-page .founder-shift-copy p,
+  .founder-page .founder-doctrine p,
+  .founder-page .founder-contact-aside p {
+    text-align: justify;
+    text-align-last: left;
+    text-justify: inter-word;
+    hyphens: auto;
+  }
+}

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-1">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## What changed

- Justifies long-form editorial paragraphs on the two founder pages at desktop widths.
- Keeps headings, buttons, labels, short thesis copy and card text naturally aligned.
- Preserves mobile readability by leaving narrow layouts ragged-right.
- Bumps the dedicated founder stylesheet version in EN and FR.

## Why

The founder reputation page needs a more formal editorial rhythm without introducing spacing rivers in short or narrow text.

## Validation

- `git diff --check` passes.
- EN/FR selectors and stylesheet version verified.
- PDF output test passes.
- Existing hash placeholder and JSON Schema test issues are unrelated to this CSS-only change.