### PR TITLE
Add TruthX contact form to founder page

### DIFF
--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -987,9 +987,9 @@
 
 .founder-page .founder-contact-grid {
   display: grid;
-  grid-template-columns: minmax(0, .64fr) minmax(310px, .36fr);
-  gap: 80px;
-  align-items: end;
+  grid-template-columns: minmax(0, .56fr) minmax(430px, .44fr);
+  gap: clamp(48px, 6vw, 92px);
+  align-items: center;
 }
 
 .founder-page .founder-contact .founder-section-title {
@@ -997,29 +997,263 @@
 }
 
 .founder-page .founder-contact-aside {
-  padding: 29px;
+  position: relative;
+  overflow: hidden;
+  padding: clamp(29px, 3vw, 42px);
   border: 1px solid var(--founder-line);
-  background: rgba(8, 12, 16, .72);
-  box-shadow: 0 30px 80px rgba(0, 0, 0, .32);
+  background:
+    radial-gradient(520px 340px at 96% 0%, rgba(196, 154, 88, .10), transparent 65%),
+    rgba(8, 12, 16, .82);
+  box-shadow: 0 34px 90px rgba(0, 0, 0, .38), inset 0 1px 0 rgba(255, 255, 255, .025);
+  backdrop-filter: blur(14px);
+}
+
+.founder-page .founder-contact-aside::before {
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(225, 195, 138, .055);
+  content: "";
+  pointer-events: none;
 }
 
 .founder-page .founder-contact-aside p {
+  position: relative;
+  z-index: 1;
   margin: 0;
   color: var(--founder-soft);
   font-size: 14px;
   line-height: 1.78;
 }
 
+.founder-page .founder-contact-aside .founder-form-kicker {
+  margin: 0 0 15px;
+  color: var(--founder-gold);
+  font: 600 8px/1.5 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1.7px;
+}
+
+.founder-page .founder-contact-aside h3 {
+  position: relative;
+  z-index: 1;
+  max-width: 520px;
+  margin: 0;
+  color: var(--founder-text);
+  font: 500 clamp(21px, 2vw, 29px)/1.18 Orbitron, Montserrat, sans-serif;
+  letter-spacing: -.025em;
+}
+
+.founder-page .founder-contact-aside .founder-contact-intro {
+  max-width: 520px;
+  margin-top: 14px;
+  text-align: left;
+}
+
 .founder-page .founder-contact-email {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   min-height: 44px;
   align-items: center;
-  margin-top: 24px;
+  margin-top: 15px;
   padding-bottom: 7px;
   border-bottom: 1px solid rgba(225, 195, 138, .50);
   color: var(--founder-gold-light);
-  font-size: 12px;
+  font-size: 11px;
   text-decoration: none;
+}
+
+.founder-page .founder-contact-form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 17px;
+  margin-top: 29px;
+}
+
+.founder-page .founder-contact-form label {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  gap: 8px;
+  color: #9fa6a6;
+  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1.15px;
+  text-transform: uppercase;
+}
+
+.founder-page .founder-contact-form label > small {
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: #666f72;
+  font: 500 7px/1.4 Montserrat, sans-serif;
+  letter-spacing: .7px;
+}
+
+.founder-page .founder-contact-form input,
+.founder-page .founder-contact-form select {
+  width: 100%;
+  height: 45px;
+  padding: 0 12px;
+  border: 1px solid #293135;
+  border-radius: 0;
+  outline: none;
+  background: rgba(4, 7, 9, .82);
+  color: #e2ded5;
+  font: 500 14px/1 Montserrat, sans-serif;
+  text-align: left;
+  text-transform: none;
+  transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
+}
+
+.founder-page .founder-contact-form input:focus,
+.founder-page .founder-contact-form select:focus {
+  border-color: var(--founder-gold);
+  background: #070a0c;
+  box-shadow: 0 0 0 3px rgba(196, 154, 88, .08);
+}
+
+.founder-page .founder-contact-form .founder-form-wide,
+.founder-page .founder-contact-form .founder-form-consent,
+.founder-page .founder-contact-form .founder-form-submit,
+.founder-page .founder-contact-form .founder-form-error,
+.founder-page .founder-contact-form .founder-form-note {
+  grid-column: 1 / -1;
+}
+
+.founder-page .founder-contact-form .founder-form-consent {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-items: flex-start;
+  color: #8f9798;
+  font-family: Montserrat, sans-serif;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.founder-page .founder-contact-form .founder-form-consent input {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+  margin-top: 2px;
+  padding: 0;
+  accent-color: var(--founder-gold);
+}
+
+.founder-page .founder-contact-form .founder-form-consent span {
+  display: grid;
+  gap: 4px;
+}
+
+.founder-page .founder-contact-form .founder-form-consent b {
+  color: #b4b8b6;
+  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.founder-page .founder-contact-form .founder-form-consent small {
+  position: static;
+  color: #747c7d;
+  font: 500 10px/1.55 Montserrat, sans-serif;
+  letter-spacing: 0;
+}
+
+.founder-page .founder-form-trap {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.founder-page .founder-form-submit {
+  display: inline-flex;
+  min-height: 49px;
+  justify-content: space-between;
+  gap: 22px;
+  align-items: center;
+  padding: 14px 17px;
+  border: 1px solid #d0b06b;
+  background: linear-gradient(110deg, #ad8747, #dfc17e);
+  color: #090b0d;
+  font: 700 9px/1.3 Montserrat, sans-serif;
+  letter-spacing: 1.25px;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 16px 42px rgba(173, 135, 71, .14);
+  transition: transform .2s ease, filter .2s ease, opacity .2s ease;
+}
+
+.founder-page .founder-form-submit:hover,
+.founder-page .founder-form-submit:focus-visible {
+  filter: brightness(1.08);
+  transform: translateY(-2px);
+}
+
+.founder-page .founder-form-submit:disabled {
+  opacity: .65;
+  cursor: wait;
+  transform: none;
+}
+
+.founder-page .founder-form-error,
+.founder-page .founder-form-note {
+  display: block;
+  text-align: left;
+  text-transform: none;
+}
+
+.founder-page .founder-form-error {
+  color: #e4a38e;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.founder-page .founder-form-error:empty {
+  display: none;
+}
+
+.founder-page .founder-form-note {
+  color: #626b6c;
+  font-size: 9px;
+  line-height: 1.55;
+}
+
+.founder-page .founder-form-success {
+  position: relative;
+  z-index: 1;
+  margin-top: 30px;
+  padding: 24px;
+  border-left: 2px solid var(--founder-gold);
+  background: rgba(196, 154, 88, .045);
+}
+
+.founder-page .founder-form-success[hidden] {
+  display: none;
+}
+
+.founder-page .founder-form-success strong {
+  color: var(--founder-gold-light);
+  font: 600 15px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1px;
+}
+
+.founder-page .founder-form-success p {
+  margin-top: 12px;
+  text-align: left;
+}
+
+.founder-page .founder-form-noscript {
+  margin-top: 24px !important;
+  text-align: left !important;
+}
+
+.founder-page .founder-form-noscript a {
+  color: var(--founder-gold-light);
 }
 
 /* Motion progressively enabled by founder-reputation.js */
@@ -1186,6 +1420,14 @@
   .founder-page .founder-doctrine blockquote { font-size: 40px; }
   .founder-page .founder-contact { padding: 92px 0 86px; }
   .founder-page .founder-contact-grid { gap: 48px; }
+  .founder-page .founder-contact-aside { padding: 25px 21px; }
+  .founder-page .founder-contact-form { grid-template-columns: 1fr; }
+  .founder-page .founder-contact-form .founder-form-wide,
+  .founder-page .founder-contact-form .founder-form-consent,
+  .founder-page .founder-contact-form .founder-form-submit,
+  .founder-page .founder-contact-form .founder-form-error,
+  .founder-page .founder-contact-form .founder-form-note { grid-column: auto; }
+  .founder-page .founder-contact-email { font-size: 10px; }
 }
 
 @media (hover: none), (pointer: coarse) {
@@ -1233,8 +1475,7 @@
   .founder-page .founder-origin-event p,
   .founder-page .founder-method-copy p,
   .founder-page .founder-shift-copy p,
-  .founder-page .founder-doctrine p,
-  .founder-page .founder-contact-aside p {
+  .founder-page .founder-doctrine p {
     text-align: justify;
     text-align-last: left;
     text-justify: inter-word;

--- a/docs/assets/founder-reputation.js
+++ b/docs/assets/founder-reputation.js
@@ -146,4 +146,115 @@
   motionQuery.addEventListener?.('change', syncMotionPreference);
   finePointerQuery.addEventListener?.('change', syncMotionPreference);
   syncMotionPreference();
+
+  const contactForm = page.querySelector('[data-founder-contact-form]');
+  if (contactForm) {
+    const endpoint = 'https://truthx.co/api/subscribers';
+    const field = name => contactForm.elements.namedItem(name);
+    const interest = field('interest');
+    const marketingConsent = field('marketingConsent');
+    const submitButton = contactForm.querySelector('.founder-form-submit');
+    const submitText = contactForm.querySelector('[data-submit-text]');
+    const errorMessage = contactForm.querySelector('.founder-form-error');
+    const successMessage = page.querySelector('[data-form-success]');
+    const firstField = field('firstname');
+
+    const syncMarketingConsent = () => {
+      const required = interest?.value === 'proof-briefs';
+      if (!marketingConsent) return;
+      marketingConsent.required = required;
+      marketingConsent.setAttribute('aria-required', String(required));
+    };
+
+    const attributionSource = language => {
+      const trackedParams = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+      const search = new URLSearchParams(window.location.search);
+      const attribution = trackedParams
+        .map(key => [key, search.get(key)])
+        .filter(([, value]) => value)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('&');
+
+      return [
+        `rpo.openproof.net:${window.location.pathname || '/'}`,
+        'form=founder-contact',
+        `lang=${language}`,
+        attribution
+      ].filter(Boolean).join('|');
+    };
+
+    interest?.addEventListener('change', syncMarketingConsent);
+    syncMarketingConsent();
+
+    page.querySelectorAll('[data-contact-focus]').forEach(link => {
+      link.addEventListener('click', () => {
+        window.setTimeout(() => firstField?.focus({ preventScroll: true }), motionQuery.matches ? 0 : 550);
+      });
+    });
+
+    contactForm.addEventListener('submit', async event => {
+      event.preventDefault();
+      syncMarketingConsent();
+      if (!contactForm.reportValidity()) return;
+
+      const language = contactForm.dataset.language === 'en' ? 'en' : 'fr';
+      const formData = new FormData(contactForm);
+      const firstName = String(formData.get('firstname') || '').trim();
+      const lastName = String(formData.get('lastname') || '').trim();
+      const email = String(formData.get('email') || '').trim().toLowerCase();
+      const company = String(formData.get('company') || '').trim();
+      const selectedInterest = String(formData.get('interest') || 'partnership');
+      const processingConsent = formData.get('processingConsent') === 'on';
+      const publicationsConsent = formData.get('marketingConsent') === 'on';
+      const website = String(formData.get('website') || '').trim();
+
+      submitButton.disabled = true;
+      submitText.textContent = contactForm.dataset.sendingLabel || submitText.textContent;
+      errorMessage.textContent = '';
+
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            firstName,
+            lastName,
+            name: [firstName, lastName].filter(Boolean).join(' '),
+            email,
+            company,
+            interest: selectedInterest,
+            consent: processingConsent,
+            processingConsent,
+            marketingConsent: publicationsConsent,
+            source: attributionSource(language),
+            language,
+            pageUri: window.location.href,
+            pageName: contactForm.dataset.pageName || document.title,
+            hubspotUtk: '',
+            website
+          })
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          const message = response.status === 400 && result.error
+            ? result.error
+            : contactForm.dataset.errorLabel;
+          throw new Error(message);
+        }
+
+        contactForm.hidden = true;
+        if (successMessage) {
+          successMessage.hidden = false;
+          successMessage.focus({ preventScroll: true });
+        }
+      } catch (error) {
+        errorMessage.textContent = error instanceof Error && error.message
+          ? error.message
+          : contactForm.dataset.errorLabel;
+      } finally {
+        submitButton.disabled = false;
+        submitText.textContent = contactForm.dataset.submitLabel || submitText.textContent;
+      }
+    });
+  }
 })();

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-3">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>La vérité ne suffit pas.<span>Elle doit pouvoir résister au pouvoir du récit.</span></h1>
           <p class="founder-hero-lead">Quand les faits, les responsabilités et les décisions ne s’alignent plus, Gersende de Parcey reconstruit la mécanique réelle d’une situation — puis rend cette reconstruction lisible, traçable et vérifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20ou%20partenariat%20%E2%80%94%20Gersende%20de%20Parcey">Discuter d’une mission ou d’un partenariat</a>
+            <a class="btn primary" href="#founder-contact-form" data-contact-focus>Discuter d’une mission ou d’un partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
@@ -287,14 +287,51 @@
           <p class="founder-kicker">Mission · Partenariat</p>
           <h2 class="founder-section-title">Une situation critique mérite mieux qu’une opinion de plus.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20ou%20partenariat%20%E2%80%94%20Gersende%20de%20Parcey">Me contacter — mission ou partenariat</a>
+            <a class="btn primary" href="#founder-contact-form" data-contact-focus>Me contacter — mission ou partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p>Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
+          <p class="founder-form-kicker">TRUTHX SIGNAL · MISSION / PARTENARIAT</p>
+          <h3>RESTER CONNECTÉ AU SYSTÈME.</h3>
+          <p class="founder-contact-intro">Recevez les Proof Briefs ou signalez un projet de partenariat.</p>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a>
+
+          <form id="founder-contact-form" class="founder-contact-form" data-founder-contact-form data-language="fr" data-page-name="Gersende de Parcey — Fondatrice OpenProof" data-submit-label="TRANSMETTRE" data-sending-label="ENREGISTREMENT…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
+            <label>Prénom<input type="text" name="firstname" autocomplete="given-name" required></label>
+            <label>Nom<input type="text" name="lastname" autocomplete="family-name" required></label>
+            <label>E-mail professionnel<input type="email" name="email" autocomplete="email" required></label>
+            <label>Organisation <small>Facultatif</small><input type="text" name="company" autocomplete="organization"></label>
+            <label class="founder-form-wide">Votre intérêt
+              <select name="interest" required>
+                <option value="proof-briefs">Recevoir les Proof Briefs</option>
+                <option value="enterprise">Cas d’usage entreprise</option>
+                <option value="legal">Droit et preuve</option>
+                <option value="research">Recherche</option>
+                <option value="investment">Investissement</option>
+                <option value="partnership" selected>Partenariat</option>
+              </select>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="processingConsent" required>
+              <span><b>Traitement de la demande</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="marketingConsent">
+              <span><b>Publications TruthX</b><small>Je souhaite recevoir les Proof Briefs et invitations correspondant à mon intérêt. Désinscription possible à tout moment.</small></span>
+            </label>
+            <div class="founder-form-trap" aria-hidden="true"><label>Site internet<input type="text" name="website" tabindex="-1" autocomplete="off"></label></div>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>TRANSMETTRE</span><span aria-hidden="true">→</span></button>
+            <small class="founder-form-error" role="alert" aria-live="polite"></small>
+            <small class="founder-form-note">Vos données servent uniquement à vous adresser les contenus demandés et à qualifier les demandes de partenariat.</small>
+          </form>
+
+          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
+            <strong>DEMANDE ENREGISTRÉE.</strong>
+            <p>Votre demande a bien été transmise. Les publications ne seront envoyées que si vous avez donné votre accord.</p>
+          </div>
+          <noscript><p class="founder-form-noscript">Pour transmettre votre demande, écrivez à <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
@@ -312,6 +349,6 @@
     </div>
   </footer>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260731-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260731-2"></script>
 </body>
 </html>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-3">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>Truth is not enough.<span>It must withstand the power of narrative.</span></h1>
           <p class="founder-hero-lead">When facts, accountability and decisions no longer align, Gersende de Parcey reconstructs the real mechanics of a situation — then makes that reconstruction legible, traceable and verifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20or%20partnership%20%E2%80%94%20Gersende%20de%20Parcey">Discuss a mission or partnership</a>
+            <a class="btn primary" href="#founder-contact-form" data-contact-focus>Discuss a mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
@@ -287,14 +287,51 @@
           <p class="founder-kicker">Mission · Partnership</p>
           <h2 class="founder-section-title">A critical situation deserves more than another opinion.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20or%20partnership%20%E2%80%94%20Gersende%20de%20Parcey">Contact me — mission or partnership</a>
+            <a class="btn primary" href="#founder-contact-form" data-contact-focus>Contact me — mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p>Gersende de Parcey works alongside leaders when facts must be reconstructed, accountability clarified and the basis for decision made more robust. She also engages with research, institutional and technology partners able to test, strengthen or deploy OpenProof.</p>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
+          <p class="founder-form-kicker">TRUTHX SIGNAL · MISSION / PARTNERSHIP</p>
+          <h3>STAY CONNECTED TO THE SYSTEM.</h3>
+          <p class="founder-contact-intro">Receive Proof Briefs or tell us about a partnership opportunity.</p>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a>
+
+          <form id="founder-contact-form" class="founder-contact-form" data-founder-contact-form data-language="en" data-page-name="Gersende de Parcey — Founder of OpenProof" data-submit-label="SUBMIT" data-sending-label="SUBMITTING…" data-error-label="Your message could not be sent. Try again or email openproof@truthx.co directly.">
+            <label>First name<input type="text" name="firstname" autocomplete="given-name" required></label>
+            <label>Last name<input type="text" name="lastname" autocomplete="family-name" required></label>
+            <label>Professional email<input type="email" name="email" autocomplete="email" required></label>
+            <label>Organisation <small>Optional</small><input type="text" name="company" autocomplete="organization"></label>
+            <label class="founder-form-wide">Your interest
+              <select name="interest" required>
+                <option value="proof-briefs">Receive Proof Briefs</option>
+                <option value="enterprise">Enterprise use case</option>
+                <option value="legal">Law and evidence</option>
+                <option value="research">Research</option>
+                <option value="investment">Investment</option>
+                <option value="partnership" selected>Partnership</option>
+              </select>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="processingConsent" required>
+              <span><b>Request processing</b><small>I agree that TruthX and OpenProof may store and process my data in order to respond to my request.</small></span>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="marketingConsent">
+              <span><b>TruthX publications</b><small>I would like to receive Proof Briefs and invitations relevant to my interest. I can unsubscribe at any time.</small></span>
+            </label>
+            <div class="founder-form-trap" aria-hidden="true"><label>Website<input type="text" name="website" tabindex="-1" autocomplete="off"></label></div>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>SUBMIT</span><span aria-hidden="true">→</span></button>
+            <small class="founder-form-error" role="alert" aria-live="polite"></small>
+            <small class="founder-form-note">Your data is used only to send the requested content and qualify partnership enquiries.</small>
+          </form>
+
+          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
+            <strong>REQUEST RECORDED.</strong>
+            <p>Your request has been submitted. Publications will only be sent if you gave your consent.</p>
+          </div>
+          <noscript><p class="founder-form-noscript">To send your request, email <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
@@ -312,6 +349,6 @@
     </div>
   </footer>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260731-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260731-2"></script>
 </body>
 </html>


### PR DESCRIPTION
## What changed

- replaces the final founder-page contact card with the shared TruthX signal form in French and English
- routes submissions to the existing TruthX `/api/subscribers` endpoint connected to HubSpot
- records the RPO page path, form identity, language and UTM attribution
- preserves `openproof@truthx.co` as the direct-contact fallback
- points both mission/partnership CTAs to the embedded form

## Why

The RPO founder page should use the same contact system as TruthX so there is one form logic, one contact pipeline and one HubSpot destination to maintain.

## Impact

Visitors can submit a mission, partnership, research, legal, enterprise, investment or Proof Briefs interest without leaving the RPO page. The TruthX gateway is restricted to the approved TruthX and RPO browser origins.

## Validation

- four-file scope verified against `main`
- `git diff --check` passed
- JavaScript syntax passed
- French/English source and language attribution verified
- TruthX CORS gateway deployed and verified before this PR
- responsive and consent states included