### PR TITLE
Restore native HubSpot contact forms on founder pages

### DIFF
--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -989,7 +989,7 @@
   display: grid;
   grid-template-columns: minmax(0, .64fr) minmax(310px, .36fr);
   gap: 80px;
-  align-items: end;
+  align-items: start;
 }
 
 .founder-page .founder-contact .founder-section-title {
@@ -1003,11 +1003,18 @@
   box-shadow: 0 30px 80px rgba(0, 0, 0, .32);
 }
 
-.founder-page .founder-contact-aside p {
+.founder-page .founder-contact-aside > .founder-contact-copy {
   margin: 0;
   color: var(--founder-soft);
   font-size: 14px;
   line-height: 1.78;
+}
+
+.founder-page .founder-hubspot-form {
+  width: 100%;
+  margin-top: 28px;
+  scroll-margin-top: 100px;
+  background: #fff;
 }
 
 .founder-page .founder-contact-email {
@@ -1234,7 +1241,7 @@
   .founder-page .founder-method-copy p,
   .founder-page .founder-shift-copy p,
   .founder-page .founder-doctrine p,
-  .founder-page .founder-contact-aside p {
+  .founder-page .founder-contact-aside > .founder-contact-copy {
     text-align: justify;
     text-align-last: left;
     text-justify: inter-word;

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-1">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>La vérité ne suffit pas.<span>Elle doit pouvoir résister au pouvoir du récit.</span></h1>
           <p class="founder-hero-lead">Quand les faits, les responsabilités et les décisions ne s’alignent plus, Gersende de Parcey reconstruit la mécanique réelle d’une situation — puis rend cette reconstruction lisible, traçable et vérifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20ou%20partenariat%20%E2%80%94%20Gersende%20de%20Parcey">Discuter d’une mission ou d’un partenariat</a>
+            <a class="btn primary" href="#rpo-contact-form-fr">Discuter d’une mission ou d’un partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
@@ -287,13 +287,14 @@
           <p class="founder-kicker">Mission · Partenariat</p>
           <h2 class="founder-section-title">Une situation critique mérite mieux qu’une opinion de plus.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20ou%20partenariat%20%E2%80%94%20Gersende%20de%20Parcey">Me contacter — mission ou partenariat</a>
+            <a class="btn primary" href="#rpo-contact-form-fr">Me contacter — mission ou partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p>Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
+          <p class="founder-contact-copy">Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
+          <div id="rpo-contact-form-fr" class="founder-hubspot-form hs-form-frame" data-region="na1" data-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-portal-id="49371550"></div>
           <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
         </aside>
       </div>
@@ -311,6 +312,7 @@
       </div>
     </div>
   </footer>
+  <script src="https://js.hsforms.net/forms/embed/49371550.js" defer></script>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
   <script src="/assets/founder-reputation.js?v=20260731-1"></script>
 </body>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260731-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-1">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>Truth is not enough.<span>It must withstand the power of narrative.</span></h1>
           <p class="founder-hero-lead">When facts, accountability and decisions no longer align, Gersende de Parcey reconstructs the real mechanics of a situation — then makes that reconstruction legible, traceable and verifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20or%20partnership%20%E2%80%94%20Gersende%20de%20Parcey">Discuss a mission or partnership</a>
+            <a class="btn primary" href="#rpo-contact-form-en">Discuss a mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
@@ -287,13 +287,14 @@
           <p class="founder-kicker">Mission · Partnership</p>
           <h2 class="founder-section-title">A critical situation deserves more than another opinion.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="mailto:openproof@truthx.co?subject=Mission%20or%20partnership%20%E2%80%94%20Gersende%20de%20Parcey">Contact me — mission or partnership</a>
+            <a class="btn primary" href="#rpo-contact-form-en">Contact me — mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p>Gersende de Parcey works alongside leaders when facts must be reconstructed, accountability clarified and the basis for decision made more robust. She also engages with research, institutional and technology partners able to test, strengthen or deploy OpenProof.</p>
+          <p class="founder-contact-copy">Gersende de Parcey works alongside leaders when facts must be reconstructed, accountability clarified and the basis for decision made more robust. She also engages with research, institutional and technology partners able to test, strengthen or deploy OpenProof.</p>
+          <div id="rpo-contact-form-en" class="founder-hubspot-form hs-form-frame" data-region="na1" data-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-portal-id="49371550"></div>
           <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
         </aside>
       </div>
@@ -311,6 +312,7 @@
       </div>
     </div>
   </footer>
+  <script src="https://js.hsforms.net/forms/embed/49371550.js" defer></script>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
   <script src="/assets/founder-reputation.js?v=20260731-1"></script>
 </body>


### PR DESCRIPTION
## Summary
- embed a dedicated native HubSpot form on the French founder page
- embed the translated native HubSpot form on the English founder page
- keep `openproof@truthx.co` visible as a direct fallback
- point the two mission/partnership CTAs to the form
- preserve justified editorial copy without justifying HubSpot consent or validation text

## Reliability
- submissions go directly from the RPO page to HubSpot
- no TruthX API bridge and no client-side success simulation
- the free-text message uses the dedicated HubSpot property `rpo__message_de_contact`
- `rpo.openproof.net` is registered as an additional HubSpot site domain

## Scope
Only the two founder HTML pages and their page-scoped stylesheet are changed.