### PR TITLE
Match RPO contact form to TruthX brand

### DIFF
--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -987,9 +987,9 @@
 
 .founder-page .founder-contact-grid {
   display: grid;
-  grid-template-columns: minmax(0, .64fr) minmax(310px, .36fr);
-  gap: 80px;
-  align-items: start;
+  grid-template-columns: minmax(0, .56fr) minmax(430px, .44fr);
+  gap: clamp(48px, 6vw, 92px);
+  align-items: center;
 }
 
 .founder-page .founder-contact .founder-section-title {
@@ -997,36 +997,270 @@
 }
 
 .founder-page .founder-contact-aside {
-  padding: 29px;
+  position: relative;
+  overflow: hidden;
+  padding: clamp(29px, 3vw, 42px);
   border: 1px solid var(--founder-line);
-  background: rgba(8, 12, 16, .72);
-  box-shadow: 0 30px 80px rgba(0, 0, 0, .32);
+  background:
+    radial-gradient(520px 340px at 96% 0%, rgba(196, 154, 88, .10), transparent 65%),
+    rgba(8, 12, 16, .86);
+  box-shadow: 0 34px 90px rgba(0, 0, 0, .38), inset 0 1px 0 rgba(255, 255, 255, .025);
+  backdrop-filter: blur(14px);
+}
+
+.founder-page .founder-contact-aside::before {
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(225, 195, 138, .055);
+  content: "";
+  pointer-events: none;
 }
 
 .founder-page .founder-contact-aside > .founder-contact-copy {
+  position: relative;
+  z-index: 1;
   margin: 0;
   color: var(--founder-soft);
   font-size: 14px;
   line-height: 1.78;
 }
 
-.founder-page .founder-hubspot-form {
-  width: 100%;
-  margin-top: 28px;
-  scroll-margin-top: 100px;
-  background: #fff;
+.founder-page .founder-signal-head {
+  position: relative;
+  z-index: 1;
+  margin-top: 30px;
+  padding-top: 27px;
+  border-top: 1px solid rgba(225, 195, 138, .16);
+}
+
+.founder-page .founder-contact-aside .founder-form-kicker {
+  margin: 0 0 15px;
+  color: var(--founder-gold);
+  font: 600 8px/1.5 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1.7px;
+}
+
+.founder-page .founder-contact-aside h3 {
+  max-width: 540px;
+  margin: 0;
+  color: var(--founder-text);
+  font: 500 clamp(21px, 2vw, 29px)/1.18 Orbitron, Montserrat, sans-serif;
+  letter-spacing: -.025em;
+}
+
+.founder-page .founder-contact-aside .founder-contact-intro {
+  max-width: 540px;
+  margin: 14px 0 0;
+  color: var(--founder-soft);
+  font-size: 13px;
+  line-height: 1.65;
+  text-align: left;
 }
 
 .founder-page .founder-contact-email {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
-  min-height: 44px;
+  min-height: 38px;
   align-items: center;
-  margin-top: 24px;
-  padding-bottom: 7px;
+  margin-top: 12px;
+  padding-bottom: 6px;
   border-bottom: 1px solid rgba(225, 195, 138, .50);
   color: var(--founder-gold-light);
-  font-size: 12px;
+  font-size: 10px;
   text-decoration: none;
+}
+
+.founder-page .founder-contact-form {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 28px;
+  scroll-margin-top: 100px;
+}
+
+.founder-page .founder-contact-form[hidden] {
+  display: none;
+}
+
+.founder-page .founder-contact-form label {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  gap: 8px;
+  color: #9fa4a3;
+  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+}
+
+.founder-page .founder-contact-form input,
+.founder-page .founder-contact-form textarea {
+  width: 100%;
+  height: 46px;
+  padding: 0 12px;
+  border: 1px solid #29302f;
+  border-radius: 0;
+  outline: none;
+  background: #070a0b;
+  color: #e2ded5;
+  font: 500 13px/1 Montserrat, sans-serif;
+  text-align: left;
+  text-transform: none;
+  transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
+}
+
+.founder-page .founder-contact-form input:focus,
+.founder-page .founder-contact-form textarea:focus {
+  border-color: var(--founder-gold);
+  background: #090d0e;
+  box-shadow: 0 0 0 3px rgba(196, 154, 88, .08);
+}
+
+.founder-page .founder-contact-form .founder-form-wide,
+.founder-page .founder-contact-form .founder-form-consent,
+.founder-page .founder-contact-form .founder-form-error,
+.founder-page .founder-contact-form .founder-form-note {
+  grid-column: 1 / -1;
+}
+
+.founder-page .founder-contact-form textarea {
+  min-height: 104px;
+  padding: 12px;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+.founder-page .founder-contact-form .founder-form-consent {
+  display: flex;
+  flex-direction: row;
+  gap: 11px;
+  align-items: flex-start;
+  color: #8f9798;
+  font-family: Montserrat, sans-serif;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.founder-page .founder-contact-form .founder-form-consent input {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  padding: 0;
+  accent-color: var(--founder-gold);
+}
+
+.founder-page .founder-contact-form .founder-form-consent span {
+  display: grid;
+  gap: 4px;
+}
+
+.founder-page .founder-contact-form .founder-form-consent b {
+  color: #b4b8b6;
+  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.founder-page .founder-contact-form .founder-form-consent small {
+  color: #747c7d;
+  font: 500 10px/1.55 Montserrat, sans-serif;
+  letter-spacing: 0;
+}
+
+.founder-page .founder-form-submit {
+  display: inline-flex;
+  width: 100%;
+  min-height: 49px;
+  justify-content: space-between;
+  gap: 22px;
+  align-items: center;
+  padding: 14px 17px;
+  border: 1px solid #d0b06b;
+  background: linear-gradient(110deg, #ad8747, #dfc17e);
+  color: #090b0d;
+  font: 700 9px/1.3 Montserrat, sans-serif;
+  letter-spacing: 1.25px;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 16px 42px rgba(173, 135, 71, .14);
+  transition: transform .2s ease, filter .2s ease, opacity .2s ease;
+}
+
+.founder-page .founder-form-submit:hover,
+.founder-page .founder-form-submit:focus-visible {
+  filter: brightness(1.08);
+  transform: translateY(-2px);
+}
+
+.founder-page .founder-form-submit:disabled {
+  opacity: .65;
+  cursor: wait;
+  transform: none;
+}
+
+.founder-page .founder-form-error,
+.founder-page .founder-form-note {
+  display: block;
+  text-align: left;
+  text-transform: none;
+}
+
+.founder-page .founder-form-error {
+  color: #e4a38e;
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.founder-page .founder-form-error:empty {
+  display: none;
+}
+
+.founder-page .founder-form-note {
+  color: #626b6c;
+  font-size: 9px;
+  line-height: 1.55;
+}
+
+.founder-page .founder-form-success {
+  position: relative;
+  z-index: 1;
+  margin-top: 28px;
+  padding: 23px;
+  border-left: 2px solid var(--founder-gold);
+  background: rgba(196, 154, 88, .045);
+}
+
+.founder-page .founder-form-success[hidden] {
+  display: none;
+}
+
+.founder-page .founder-form-success strong {
+  color: var(--founder-gold-light);
+  font: 600 14px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1px;
+}
+
+.founder-page .founder-form-success p {
+  margin-top: 11px;
+  color: var(--founder-soft);
+  font-size: 12px;
+  line-height: 1.65;
+  text-align: left;
+}
+
+.founder-page .founder-form-noscript {
+  position: relative;
+  z-index: 1;
+  margin-top: 22px !important;
+  text-align: left !important;
+}
+
+.founder-page .founder-form-noscript a {
+  color: var(--founder-gold-light);
 }
 
 /* Motion progressively enabled by founder-reputation.js */
@@ -1193,6 +1427,13 @@
   .founder-page .founder-doctrine blockquote { font-size: 40px; }
   .founder-page .founder-contact { padding: 92px 0 86px; }
   .founder-page .founder-contact-grid { gap: 48px; }
+  .founder-page .founder-contact-aside { padding: 25px 21px; }
+  .founder-page .founder-contact-form { grid-template-columns: 1fr; }
+  .founder-page .founder-contact-form .founder-form-wide,
+  .founder-page .founder-contact-form .founder-form-consent,
+  .founder-page .founder-contact-form .founder-form-error,
+  .founder-page .founder-contact-form .founder-form-note { grid-column: auto; }
+  .founder-page .founder-contact-email { font-size: 10px; }
 }
 
 @media (hover: none), (pointer: coarse) {

--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -987,9 +987,9 @@
 
 .founder-page .founder-contact-grid {
   display: grid;
-  grid-template-columns: minmax(0, .56fr) minmax(430px, .44fr);
+  grid-template-columns: minmax(0, .46fr) minmax(520px, .54fr);
   gap: clamp(48px, 6vw, 92px);
-  align-items: center;
+  align-items: start;
 }
 
 .founder-page .founder-contact .founder-section-title {
@@ -1023,6 +1023,8 @@
   color: var(--founder-soft);
   font-size: 14px;
   line-height: 1.78;
+  text-align: justify;
+  text-justify: inter-word;
 }
 
 .founder-page .founder-signal-head {
@@ -1044,7 +1046,7 @@
   max-width: 540px;
   margin: 0;
   color: var(--founder-text);
-  font: 500 clamp(21px, 2vw, 29px)/1.18 Orbitron, Montserrat, sans-serif;
+  font: 500 clamp(30px, 3vw, 44px)/1.12 Orbitron, Montserrat, sans-serif;
   letter-spacing: -.025em;
 }
 
@@ -1052,7 +1054,7 @@
   max-width: 540px;
   margin: 14px 0 0;
   color: var(--founder-soft);
-  font-size: 13px;
+  font-size: 15px;
   line-height: 1.65;
   text-align: left;
 }
@@ -1063,7 +1065,7 @@
   display: inline-flex;
   min-height: 38px;
   align-items: center;
-  margin-top: 12px;
+  margin-top: 20px;
   padding-bottom: 6px;
   border-bottom: 1px solid rgba(225, 195, 138, .50);
   color: var(--founder-gold-light);
@@ -1076,8 +1078,8 @@
   z-index: 1;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 18px;
-  margin-top: 28px;
+  gap: 20px;
+  margin-top: 30px;
   scroll-margin-top: 100px;
 }
 
@@ -1091,16 +1093,16 @@
   flex-direction: column;
   gap: 8px;
   color: #9fa4a3;
-  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1.1px;
+  font: 600 10px/1.4 Orbitron, Montserrat, sans-serif;
+  letter-spacing: 1.05px;
   text-transform: uppercase;
 }
 
 .founder-page .founder-contact-form input,
 .founder-page .founder-contact-form textarea {
   width: 100%;
-  height: 46px;
-  padding: 0 12px;
+  height: 54px;
+  padding: 0 14px;
   border: 1px solid #29302f;
   border-radius: 0;
   outline: none;
@@ -1160,21 +1162,21 @@
 
 .founder-page .founder-contact-form .founder-form-consent b {
   color: #b4b8b6;
-  font: 600 8px/1.4 Orbitron, Montserrat, sans-serif;
+  font: 600 10px/1.4 Orbitron, Montserrat, sans-serif;
   letter-spacing: 1px;
   text-transform: uppercase;
 }
 
 .founder-page .founder-contact-form .founder-form-consent small {
   color: #747c7d;
-  font: 500 10px/1.55 Montserrat, sans-serif;
+  font: 500 12px/1.55 Montserrat, sans-serif;
   letter-spacing: 0;
 }
 
 .founder-page .founder-form-submit {
   display: inline-flex;
   width: 100%;
-  min-height: 49px;
+  min-height: 56px;
   justify-content: space-between;
   gap: 22px;
   align-items: center;
@@ -1182,7 +1184,7 @@
   border: 1px solid #d0b06b;
   background: linear-gradient(110deg, #ad8747, #dfc17e);
   color: #090b0d;
-  font: 700 9px/1.3 Montserrat, sans-serif;
+  font: 700 10px/1.3 Montserrat, sans-serif;
   letter-spacing: 1.25px;
   text-transform: uppercase;
   cursor: pointer;

--- a/docs/assets/founder-reputation.js
+++ b/docs/assets/founder-reputation.js
@@ -163,11 +163,11 @@
     const copy = language === 'fr'
       ? {
           processing: 'J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.',
-          marketing: 'Je souhaite recevoir les Proof Briefs et invitations correspondant à mon intérêt. Désinscription possible à tout moment.'
+          marketing: 'Je souhaite recevoir les synthèses et invitations de TruthX. Je peux me désabonner à tout moment.'
         }
       : {
           processing: 'I agree that TruthX and OpenProof may store and process my data in order to respond to my request.',
-          marketing: 'I would like to receive Proof Briefs and invitations relevant to my interest. I can unsubscribe at any time.'
+          marketing: 'I would like to receive TruthX briefs and invitations. I can unsubscribe at any time.'
         };
 
     const readHubSpotCookie = () => {
@@ -227,17 +227,16 @@
               consent: {
                 consentToProcess: processingConsent,
                 text: copy.processing,
-                communications: [{
-                  value: marketingConsent,
+                communications: marketingConsent ? [{
+                  value: true,
                   subscriptionTypeId,
                   text: copy.marketing
-                }]
+                }] : []
               }
             }
           })
         });
 
-        const result = await response.json().catch(() => ({}));
         if (!response.ok) {
           throw new Error(contactForm.dataset.errorLabel);
         }

--- a/docs/assets/founder-reputation.js
+++ b/docs/assets/founder-reputation.js
@@ -216,28 +216,43 @@
       try {
         if (!formId) throw new Error(contactForm.dataset.errorLabel);
 
-        const response = await fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`, {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            submittedAt: String(Date.now()),
-            fields,
-            context,
-            legalConsentOptions: {
-              consent: {
-                consentToProcess: processingConsent,
-                text: copy.processing,
-                communications: marketingConsent ? [{
-                  value: true,
-                  subscriptionTypeId,
-                  text: copy.marketing
-                }] : []
+        const controller = new AbortController();
+        const timeoutId = window.setTimeout(() => controller.abort(), 15000);
+        let response;
+
+        try {
+          response = await fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            signal: controller.signal,
+            body: JSON.stringify({
+              submittedAt: String(Date.now()),
+              fields,
+              context,
+              legalConsentOptions: {
+                consent: {
+                  consentToProcess: processingConsent,
+                  text: copy.processing,
+                  communications: marketingConsent ? [{
+                    value: true,
+                    subscriptionTypeId,
+                    text: copy.marketing
+                  }] : []
+                }
               }
-            }
-          })
-        });
+            })
+          });
+        } finally {
+          window.clearTimeout(timeoutId);
+        }
 
         if (!response.ok) {
+          const details = await response.json().catch(() => ({}));
+          console.error('HubSpot form submission failed', {
+            status: response.status,
+            message: typeof details.message === 'string' ? details.message : '',
+            correlationId: typeof details.correlationId === 'string' ? details.correlationId : ''
+          });
           throw new Error(contactForm.dataset.errorLabel);
         }
 

--- a/docs/assets/founder-reputation.js
+++ b/docs/assets/founder-reputation.js
@@ -146,4 +146,116 @@
   motionQuery.addEventListener?.('change', syncMotionPreference);
   finePointerQuery.addEventListener?.('change', syncMotionPreference);
   syncMotionPreference();
+
+  const contactForm = page.querySelector('[data-founder-contact-form]');
+  if (contactForm) {
+    const portalId = '49371550';
+    const subscriptionTypeId = 614615597;
+    const formId = contactForm.dataset.hubspotFormId;
+    const language = contactForm.dataset.language === 'en' ? 'en' : 'fr';
+    const field = name => contactForm.elements.namedItem(name);
+    const submitButton = contactForm.querySelector('.founder-form-submit');
+    const submitText = contactForm.querySelector('[data-submit-text]');
+    const errorMessage = contactForm.querySelector('.founder-form-error');
+    const successMessage = page.querySelector('[data-form-success]');
+    const firstField = field('firstname');
+
+    const copy = language === 'fr'
+      ? {
+          processing: 'J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.',
+          marketing: 'Je souhaite recevoir les Proof Briefs et invitations correspondant à mon intérêt. Désinscription possible à tout moment.'
+        }
+      : {
+          processing: 'I agree that TruthX and OpenProof may store and process my data in order to respond to my request.',
+          marketing: 'I would like to receive Proof Briefs and invitations relevant to my interest. I can unsubscribe at any time.'
+        };
+
+    const readHubSpotCookie = () => {
+      const match = document.cookie.match(/(?:^|;\s*)hubspotutk=([^;]+)/);
+      return match ? decodeURIComponent(match[1]) : '';
+    };
+
+    page.querySelectorAll('[data-contact-focus]').forEach(link => {
+      link.addEventListener('click', () => {
+        window.setTimeout(() => firstField?.focus({ preventScroll: true }), motionQuery.matches ? 0 : 550);
+      });
+    });
+
+    contactForm.addEventListener('submit', async event => {
+      event.preventDefault();
+      if (!contactForm.reportValidity()) return;
+
+      const formData = new FormData(contactForm);
+      const firstName = String(formData.get('firstname') || '').trim();
+      const lastName = String(formData.get('lastname') || '').trim();
+      const email = String(formData.get('email') || '').trim().toLowerCase();
+      const company = String(formData.get('company') || '').trim();
+      const contactMessage = String(formData.get('message') || '').trim();
+      const processingConsent = formData.get('processingConsent') === 'on';
+      const marketingConsent = formData.get('marketingConsent') === 'on';
+
+      const fields = [
+        { objectTypeId: '0-1', name: 'firstname', value: firstName },
+        { objectTypeId: '0-1', name: 'lastname', value: lastName },
+        { objectTypeId: '0-1', name: 'email', value: email },
+        { objectTypeId: '0-1', name: 'rpo__message_de_contact', value: contactMessage }
+      ];
+      if (company) fields.push({ objectTypeId: '0-1', name: 'company', value: company });
+
+      const context = {
+        pageUri: window.location.href,
+        pageName: contactForm.dataset.pageName || document.title
+      };
+      const hutk = readHubSpotCookie();
+      if (hutk) context.hutk = hutk;
+
+      submitButton.disabled = true;
+      submitText.textContent = contactForm.dataset.sendingLabel || submitText.textContent;
+      errorMessage.textContent = '';
+
+      try {
+        if (!formId) throw new Error(contactForm.dataset.errorLabel);
+
+        const response = await fetch(`https://api.hsforms.com/submissions/v3/integration/submit/${portalId}/${formId}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            submittedAt: String(Date.now()),
+            fields,
+            context,
+            legalConsentOptions: {
+              consent: {
+                consentToProcess: processingConsent,
+                text: copy.processing,
+                communications: [{
+                  value: marketingConsent,
+                  subscriptionTypeId,
+                  text: copy.marketing
+                }]
+              }
+            }
+          })
+        });
+
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(contactForm.dataset.errorLabel);
+        }
+
+        contactForm.hidden = true;
+        if (successMessage) {
+          successMessage.hidden = false;
+          successMessage.focus({ preventScroll: true });
+        }
+      } catch (error) {
+        errorMessage.textContent = error instanceof Error && error.message
+          ? error.message
+          : contactForm.dataset.errorLabel;
+      } finally {
+        submitButton.disabled = false;
+        submitText.textContent = contactForm.dataset.submitLabel || submitText.textContent;
+      }
+    });
+  }
+
 })();

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-1">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>La vérité ne suffit pas.<span>Elle doit pouvoir résister au pouvoir du récit.</span></h1>
           <p class="founder-hero-lead">Quand les faits, les responsabilités et les décisions ne s’alignent plus, Gersende de Parcey reconstruit la mécanique réelle d’une situation — puis rend cette reconstruction lisible, traçable et vérifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-fr">Discuter d’une mission ou d’un partenariat</a>
+            <a class="btn primary" href="#rpo-contact-form-fr" data-contact-focus>Discuter d’une mission ou d’un partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
@@ -287,15 +287,42 @@
           <p class="founder-kicker">Mission · Partenariat</p>
           <h2 class="founder-section-title">Une situation critique mérite mieux qu’une opinion de plus.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-fr">Me contacter — mission ou partenariat</a>
+            <a class="btn primary" href="#rpo-contact-form-fr" data-contact-focus>Me contacter — mission ou partenariat</a>
             <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
           <p class="founder-contact-copy">Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
-          <div id="rpo-contact-form-fr" class="founder-hubspot-form hs-form-frame" data-region="na1" data-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-portal-id="49371550"></div>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
+          <div class="founder-signal-head">
+            <p class="founder-form-kicker">TRUTHX SIGNAL</p>
+            <h3>RESTER CONNECTÉ AU SYSTÈME.</h3>
+            <p class="founder-contact-intro">Recevez les Proof Briefs ou signalez un projet de partenariat.</p>
+            <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a>
+          </div>
+          <form id="rpo-contact-form-fr" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="fr" data-hubspot-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-page-name="Gersende de Parcey — Fondatrice OpenProof" data-submit-label="TRANSMETTRE" data-sending-label="TRANSMISSION…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
+            <label>Prénom<input type="text" name="firstname" autocomplete="given-name" required></label>
+            <label>Nom<input type="text" name="lastname" autocomplete="family-name" required></label>
+            <label>E-mail professionnel<input type="email" name="email" autocomplete="email" required></label>
+            <label>Organisation<input type="text" name="company" autocomplete="organization"></label>
+            <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="processingConsent" required>
+              <span><b>Traitement de la demande</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="marketingConsent">
+              <span><b>Publications TruthX</b><small>Je souhaite recevoir les Proof Briefs et invitations correspondant à mon intérêt. Désinscription possible à tout moment.</small></span>
+            </label>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>TRANSMETTRE</span><span aria-hidden="true">→</span></button>
+            <small class="founder-form-error" role="alert" aria-live="polite"></small>
+            <small class="founder-form-note">Vos données servent uniquement à traiter votre demande et, avec votre accord, à vous adresser les publications TruthX.</small>
+          </form>
+          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
+            <strong>DEMANDE ENREGISTRÉE.</strong>
+            <p>Votre demande a bien été transmise. Vous serez recontacté directement.</p>
+          </div>
+          <noscript><p class="founder-form-noscript">Pour transmettre votre demande, écrivez à <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
@@ -312,8 +339,7 @@
       </div>
     </div>
   </footer>
-  <script src="https://js.hsforms.net/forms/embed/49371550.js" defer></script>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260731-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260802-1"></script>
 </body>
 </html>

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-3">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -296,28 +296,28 @@
           <p class="founder-contact-copy">Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
           <div class="founder-signal-head">
             <p class="founder-form-kicker">TRUTHX SIGNAL</p>
-            <h3>RESTER CONNECTÉ AU SYSTÈME.</h3>
-            <p class="founder-contact-intro">Recevez les Proof Briefs ou signalez un projet de partenariat.</p>
-            <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a>
+            <h3>RESTEZ CONNECTÉ AU SYSTÈME.</h3>
+            <p class="founder-contact-intro">Décrivez brièvement votre situation, votre mission ou votre proposition de partenariat. Gersende de Parcey vous répondra directement.</p>
           </div>
-          <form id="rpo-contact-form-fr" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="fr" data-hubspot-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-page-name="Gersende de Parcey — Fondatrice OpenProof" data-submit-label="TRANSMETTRE" data-sending-label="TRANSMISSION…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
+          <form id="rpo-contact-form-fr" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="fr" data-hubspot-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-page-name="Gersende de Parcey — Fondatrice OpenProof" data-submit-label="SOUMETTRE" data-sending-label="ENVOI…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
             <label>Prénom<input type="text" name="firstname" autocomplete="given-name" required></label>
-            <label>Nom<input type="text" name="lastname" autocomplete="family-name" required></label>
-            <label>E-mail professionnel<input type="email" name="email" autocomplete="email" required></label>
-            <label>Organisation<input type="text" name="company" autocomplete="organization"></label>
+            <label>Nom de famille<input type="text" name="lastname" autocomplete="family-name" required></label>
+            <label>Courriel professionnel<input type="email" name="email" autocomplete="email" required></label>
+            <label>Organisation (facultatif)<input type="text" name="company" autocomplete="organization"></label>
             <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
             <label class="founder-form-consent">
               <input type="checkbox" name="processingConsent" required>
-              <span><b>Traitement de la demande</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span>
+              <span><b>Traitement des demandes</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span>
             </label>
             <label class="founder-form-consent">
               <input type="checkbox" name="marketingConsent">
-              <span><b>Publications TruthX</b><small>Je souhaite recevoir les Proof Briefs et invitations correspondant à mon intérêt. Désinscription possible à tout moment.</small></span>
+              <span><b>Publications TruthX</b><small>Je souhaite recevoir les synthèses et invitations de TruthX. Je peux me désabonner à tout moment.</small></span>
             </label>
-            <button class="founder-form-submit" type="submit"><span data-submit-text>TRANSMETTRE</span><span aria-hidden="true">→</span></button>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>SOUMETTRE</span><span aria-hidden="true">→</span></button>
             <small class="founder-form-error" role="alert" aria-live="polite"></small>
             <small class="founder-form-note">Vos données servent uniquement à traiter votre demande et, avec votre accord, à vous adresser les publications TruthX.</small>
           </form>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a>
           <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
             <strong>DEMANDE ENREGISTRÉE.</strong>
             <p>Votre demande a bien été transmise. Vous serez recontacté directement.</p>
@@ -340,6 +340,6 @@
     </div>
   </footer>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260802-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260802-2"></script>
 </body>
 </html>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-2">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-3">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -297,14 +297,13 @@
           <div class="founder-signal-head">
             <p class="founder-form-kicker">TRUTHX SIGNAL</p>
             <h3>STAY CONNECTED TO THE SYSTEM.</h3>
-            <p class="founder-contact-intro">Receive Proof Briefs or tell us about a partnership opportunity.</p>
-            <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a>
+            <p class="founder-contact-intro">Briefly describe your situation, mission or partnership proposal. Gersende de Parcey will reply directly.</p>
           </div>
           <form id="rpo-contact-form-en" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="en" data-hubspot-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-page-name="Gersende de Parcey — Founder of OpenProof" data-submit-label="SUBMIT" data-sending-label="SUBMITTING…" data-error-label="Your message could not be sent. Try again or email openproof@truthx.co directly.">
             <label>First name<input type="text" name="firstname" autocomplete="given-name" required></label>
             <label>Last name<input type="text" name="lastname" autocomplete="family-name" required></label>
             <label>Professional email<input type="email" name="email" autocomplete="email" required></label>
-            <label>Organisation<input type="text" name="company" autocomplete="organization"></label>
+            <label>Organisation (optional)<input type="text" name="company" autocomplete="organization"></label>
             <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
             <label class="founder-form-consent">
               <input type="checkbox" name="processingConsent" required>
@@ -312,12 +311,13 @@
             </label>
             <label class="founder-form-consent">
               <input type="checkbox" name="marketingConsent">
-              <span><b>TruthX publications</b><small>I would like to receive Proof Briefs and invitations relevant to my interest. I can unsubscribe at any time.</small></span>
+              <span><b>TruthX publications</b><small>I would like to receive TruthX briefs and invitations. I can unsubscribe at any time.</small></span>
             </label>
             <button class="founder-form-submit" type="submit"><span data-submit-text>SUBMIT</span><span aria-hidden="true">→</span></button>
             <small class="founder-form-error" role="alert" aria-live="polite"></small>
             <small class="founder-form-note">Your data is used only to process your request and, with your consent, send TruthX publications.</small>
           </form>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a>
           <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
             <strong>REQUEST RECORDED.</strong>
             <p>Your request has been submitted. You will be contacted directly.</p>
@@ -340,6 +340,6 @@
     </div>
   </footer>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260802-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260802-2"></script>
 </body>
 </html>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-1">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -90,7 +90,7 @@
           <h1>Truth is not enough.<span>It must withstand the power of narrative.</span></h1>
           <p class="founder-hero-lead">When facts, accountability and decisions no longer align, Gersende de Parcey reconstructs the real mechanics of a situation — then makes that reconstruction legible, traceable and verifiable.</p>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-en">Discuss a mission or partnership</a>
+            <a class="btn primary" href="#rpo-contact-form-en" data-contact-focus>Discuss a mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
@@ -287,15 +287,42 @@
           <p class="founder-kicker">Mission · Partnership</p>
           <h2 class="founder-section-title">A critical situation deserves more than another opinion.</h2>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-en">Contact me — mission or partnership</a>
+            <a class="btn primary" href="#rpo-contact-form-en" data-contact-focus>Contact me — mission or partnership</a>
             <a class="btn" href="https://openproof.net">Discover OpenProof</a>
             <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
           </div>
         </div>
         <aside class="founder-contact-aside" data-reveal="right">
           <p class="founder-contact-copy">Gersende de Parcey works alongside leaders when facts must be reconstructed, accountability clarified and the basis for decision made more robust. She also engages with research, institutional and technology partners able to test, strengthen or deploy OpenProof.</p>
-          <div id="rpo-contact-form-en" class="founder-hubspot-form hs-form-frame" data-region="na1" data-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-portal-id="49371550"></div>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">openproof@truthx.co</a>
+          <div class="founder-signal-head">
+            <p class="founder-form-kicker">TRUTHX SIGNAL</p>
+            <h3>STAY CONNECTED TO THE SYSTEM.</h3>
+            <p class="founder-contact-intro">Receive Proof Briefs or tell us about a partnership opportunity.</p>
+            <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a>
+          </div>
+          <form id="rpo-contact-form-en" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="en" data-hubspot-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-page-name="Gersende de Parcey — Founder of OpenProof" data-submit-label="SUBMIT" data-sending-label="SUBMITTING…" data-error-label="Your message could not be sent. Try again or email openproof@truthx.co directly.">
+            <label>First name<input type="text" name="firstname" autocomplete="given-name" required></label>
+            <label>Last name<input type="text" name="lastname" autocomplete="family-name" required></label>
+            <label>Professional email<input type="email" name="email" autocomplete="email" required></label>
+            <label>Organisation<input type="text" name="company" autocomplete="organization"></label>
+            <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="processingConsent" required>
+              <span><b>Request processing</b><small>I agree that TruthX and OpenProof may store and process my data in order to respond to my request.</small></span>
+            </label>
+            <label class="founder-form-consent">
+              <input type="checkbox" name="marketingConsent">
+              <span><b>TruthX publications</b><small>I would like to receive Proof Briefs and invitations relevant to my interest. I can unsubscribe at any time.</small></span>
+            </label>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>SUBMIT</span><span aria-hidden="true">→</span></button>
+            <small class="founder-form-error" role="alert" aria-live="polite"></small>
+            <small class="founder-form-note">Your data is used only to process your request and, with your consent, send TruthX publications.</small>
+          </form>
+          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
+            <strong>REQUEST RECORDED.</strong>
+            <p>Your request has been submitted. You will be contacted directly.</p>
+          </div>
+          <noscript><p class="founder-form-noscript">To send your request, email <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
@@ -312,8 +339,7 @@
       </div>
     </div>
   </footer>
-  <script src="https://js.hsforms.net/forms/embed/49371550.js" defer></script>
   <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260731-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260802-1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Correction
- removes the unstyled native HubSpot iframe from both founder pages
- reproduces the TruthX dark/ivory/gold form language in the RPO contact card
- keeps the dedicated RPO fields without visible segmentation: first name, last name, email, optional organisation, message, request-processing consent and optional publication consent
- restores the exact “RESTEZ CONNECTÉ AU SYSTÈME.” label, keeps the institutional paragraph justified and places the direct email fallback beneath the form

## Submission path
- submits directly to the existing FR and EN RPO HubSpot form IDs through HubSpot’s CORS form-submission endpoint
- keeps language and page origin through the dedicated form ID and page context
- adds `data-hs-do-not-collect="true"` to prevent a second external-form capture
- displays success only after HubSpot returns an accepted response
- applies optional marketing consent only after an explicit opt-in, without changing an existing subscription when unchecked
- aborts stalled submissions after 15 seconds and retains the direct email fallback

## Validation
- JavaScript syntax checked
- CSS braces balanced
- FR/EN field parity verified
- native HubSpot iframe and embed script absent
- dedicated form IDs, consent mapping, required fields and cache-busted assets verified
- CORS preflight from `rpo.openproof.net` accepted by HubSpot