### PR TITLE
Publish the bilingual TruthX Engine doctrine page

### DIFF
--- a/docs/assets/openproof-v2.js
+++ b/docs/assets/openproof-v2.js
@@ -67,3 +67,98 @@
     draw();
   });
 })();
+
+(() => {
+  const links = document.querySelector('.links');
+  if (!links) return;
+
+  const isFrench = document.documentElement.lang === 'fr';
+  const base = isFrench ? '/fr/truthx-engine/' : '/truthx-engine/';
+  const items = isFrench
+    ? [
+        ['Vue d’ensemble', '#overview'],
+        ['Deux modes d’intervention', '#modes'],
+        ['Contrôles d’intégrité', '#controls'],
+        ['Applications', '#applications'],
+        ['Paysage de recherche', '#landscape']
+      ]
+    : [
+        ['Overview', '#overview'],
+        ['Two operating modes', '#modes'],
+        ['Integrity controls', '#controls'],
+        ['Applications', '#applications'],
+        ['Research landscape', '#landscape']
+      ];
+
+  let nav = links.querySelector('[data-truthx-nav]');
+  if (!nav) {
+    nav = document.createElement('div');
+    nav.className = 'truthx-nav';
+    nav.dataset.truthxNav = '';
+    nav.innerHTML = `
+      <a class="truthx-nav-main" href="${base}">TruthX Engine</a>
+      <button class="truthx-nav-toggle" type="button" aria-expanded="false" aria-label="${isFrench ? 'Ouvrir les sections TruthX Engine' : 'Open TruthX Engine sections'}">⌄</button>
+      <div class="truthx-nav-menu">
+        ${items.map(([label, hash]) => `<a href="${base}${hash}">${label}</a>`).join('')}
+      </div>`;
+    const founder = [...links.children].find(element =>
+      element.tagName === 'A' && element.getAttribute('href')?.includes('gersende-de-parcey')
+    );
+    links.insertBefore(nav, founder || links.lastElementChild);
+  }
+
+  if (location.pathname.includes('/truthx-engine/')) {
+    nav.querySelector('.truthx-nav-main')?.setAttribute('aria-current', 'page');
+  }
+
+  if (!document.getElementById('truthx-nav-styles')) {
+    const style = document.createElement('style');
+    style.id = 'truthx-nav-styles';
+    style.textContent = `
+      .truthx-nav{position:relative;display:flex;align-items:center;gap:3px}
+      .truthx-nav-main{white-space:nowrap}
+      .truthx-nav-toggle{border:0;background:transparent;color:var(--muted);padding:5px 3px;cursor:pointer;font:600 .74rem Montserrat,sans-serif}
+      .truthx-nav:hover .truthx-nav-toggle,.truthx-nav:focus-within .truthx-nav-toggle,.truthx-nav.is-open .truthx-nav-toggle{color:var(--pale)}
+      .truthx-nav-menu{position:absolute;left:-14px;top:calc(100% + 14px);z-index:30;display:none;min-width:238px;padding:10px;border:1px solid var(--line);border-radius:14px;background:rgba(5,8,14,.98);box-shadow:0 22px 60px rgba(0,0,0,.48);backdrop-filter:blur(18px)}
+      .truthx-nav-menu::before{content:"";position:absolute;left:0;right:0;top:-16px;height:16px}
+      .truthx-nav-menu a{display:block;padding:9px 10px;border-radius:9px;white-space:nowrap;text-transform:none!important;letter-spacing:.02em!important;font-size:.76rem!important}
+      .truthx-nav-menu a:hover,.truthx-nav-menu a:focus{background:rgba(212,175,55,.09);color:var(--pale)}
+      .truthx-nav.is-open .truthx-nav-menu{display:grid}
+      @media(min-width:881px){.truthx-nav:hover .truthx-nav-menu,.truthx-nav:focus-within .truthx-nav-menu{display:grid}}
+      @media(max-width:880px){
+        .truthx-nav{width:100%;display:grid;grid-template-columns:1fr auto;gap:0}
+        .truthx-nav-main{padding:6px 0}
+        .truthx-nav-toggle{padding:7px 10px}
+        .truthx-nav-menu{position:static;grid-column:1/-1;min-width:0;width:100%;margin-top:4px;padding:7px;box-shadow:none;background:rgba(255,255,255,.025)}
+        .truthx-nav-menu::before{display:none}
+        .truthx-nav-menu a{padding:8px 10px}
+      }`;
+    document.head.append(style);
+  }
+
+  const toggle = nav.querySelector('.truthx-nav-toggle');
+  const setOpen = open => {
+    nav.classList.toggle('is-open', open);
+    toggle?.setAttribute('aria-expanded', open ? 'true' : 'false');
+  };
+
+  toggle?.addEventListener('click', event => {
+    event.stopPropagation();
+    setOpen(!nav.classList.contains('is-open'));
+  });
+
+  nav.querySelectorAll('.truthx-nav-menu a').forEach(link => {
+    link.addEventListener('click', () => setOpen(false));
+  });
+
+  document.addEventListener('click', event => {
+    if (!nav.contains(event.target)) setOpen(false);
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      setOpen(false);
+      toggle?.focus();
+    }
+  });
+})();

--- a/docs/assets/truthx-engine.css
+++ b/docs/assets/truthx-engine.css
@@ -1,0 +1,153 @@
+.truthx-engine-page{background:#04050a}
+.truthx-engine-page h1,.truthx-engine-page h2,.truthx-engine-page h3,.truthx-engine-page .tx-index,.truthx-engine-page .tx-eyebrow,.truthx-engine-page .tx-crossline,.truthx-engine-page .tx-core,.truthx-engine-page .tx-node{font-family:Orbitron,Montserrat,sans-serif}
+.truthx-engine-page p,.truthx-engine-page li,.truthx-engine-page summary,.truthx-engine-page small{font-family:Montserrat,Inter,ui-sans-serif,system-ui,sans-serif}
+.tx-hero{padding:88px 0 76px;min-height:760px;display:flex;align-items:center}
+.tx-hero-grid{display:grid;grid-template-columns:minmax(0,1.08fr) minmax(390px,.92fr);gap:56px;align-items:center}
+.tx-eyebrow,.tx-index{margin:0;color:var(--pale);font-size:.69rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase}
+.tx-hero h1{font-size:clamp(3rem,6vw,6.4rem);line-height:.97;letter-spacing:-.045em;margin:20px 0 24px;max-width:930px}
+.tx-hero h1 span{display:block;margin-top:14px;color:var(--gold);font-size:.46em;line-height:1.2;letter-spacing:-.015em}
+.tx-lead{max-width:820px;margin:0;color:var(--soft);font-size:clamp(1.02rem,1.65vw,1.28rem);line-height:1.8}
+.tx-crossline{display:flex;align-items:center;flex-wrap:wrap;gap:9px;margin:30px 0 0;color:var(--muted);font-size:.63rem;letter-spacing:.12em}
+.tx-crossline b{color:var(--gold);font-size:1.35rem;font-weight:500}
+.tx-actions{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:30px}
+.tx-safe{margin:13px 0 0;color:var(--muted);font-size:.78rem}
+.tx-visual{position:relative;min-height:520px;display:grid;place-items:center}
+.tx-ring{position:absolute;border-radius:50%;left:50%;top:50%;transform:translate(-50%,-50%)}
+.tx-ring-a{width:430px;height:430px;border:1px solid rgba(212,175,55,.28);box-shadow:0 0 60px rgba(212,175,55,.05);animation:txSpin 34s linear infinite}
+.tx-ring-b{width:320px;height:320px;border:1px dashed rgba(241,230,163,.18);animation:txSpinReverse 25s linear infinite}
+.tx-ring-a::before,.tx-ring-b::before{content:"";position:absolute;inset:10%;border-radius:50%;border:1px solid rgba(93,115,255,.14)}
+.tx-core{width:148px;height:148px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid rgba(212,175,55,.52);background:radial-gradient(circle,rgba(241,230,163,.18),rgba(212,175,55,.06) 45%,rgba(2,4,11,.96) 73%);box-shadow:0 0 0 18px rgba(212,175,55,.025),0 0 90px rgba(212,175,55,.22)}
+.tx-core strong{color:var(--pale);font-size:.86rem;letter-spacing:.16em}
+.tx-core b{color:var(--gold);font-size:2.1rem;line-height:1}
+.tx-core span{color:var(--muted);font-size:.6rem;letter-spacing:.17em}
+.tx-node{position:absolute;padding:10px 13px;border:1px solid var(--line);border-radius:999px;background:rgba(6,9,16,.92);box-shadow:0 12px 32px rgba(0,0,0,.38);color:var(--soft);font-size:.62rem;letter-spacing:.1em;white-space:nowrap}
+.tx-node-1{top:5%;left:44%;transform:translateX(-50%)}
+.tx-node-2{top:26%;right:0}
+.tx-node-3{bottom:12%;right:7%}
+.tx-node-4{bottom:7%;left:4%}
+.tx-node-5{top:24%;left:0}
+.tx-section{padding:88px 0;border-top:1px solid var(--line)}
+.tx-section h2{font-size:clamp(2.1rem,4vw,4.5rem);line-height:1.08;letter-spacing:-.035em;margin:16px 0;color:var(--ink)}
+.tx-definition{background:linear-gradient(180deg,rgba(255,255,255,.015),transparent)}
+.tx-definition-grid{display:grid;grid-template-columns:minmax(0,.9fr) minmax(360px,1.1fr);gap:78px;align-items:start}
+.tx-copy p{margin:0 0 22px;color:var(--soft);font-size:1.02rem;line-height:1.85}
+.tx-boundary{margin-top:30px;padding:20px 22px;border-left:3px solid var(--gold);background:rgba(212,175,55,.07);border-radius:0 16px 16px 0;color:var(--soft)}
+.tx-boundary strong{color:var(--pale)}
+.tx-heading-row{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,.42fr);gap:50px;align-items:end;margin-bottom:34px}
+.tx-heading-row p{color:var(--muted);margin:0 0 22px;line-height:1.75}
+.tx-mode-switch{display:grid;grid-template-columns:1fr 1fr;border:1px solid var(--line);border-radius:22px 22px 0 0;overflow:hidden;background:rgba(7,10,17,.7)}
+.tx-mode-switch button{display:grid;grid-template-columns:auto 1fr;grid-template-rows:auto auto;gap:2px 14px;text-align:left;padding:24px 26px;border:0;border-right:1px solid var(--line);background:transparent;color:var(--muted);cursor:pointer}
+.tx-mode-switch button:last-child{border-right:0}
+.tx-mode-switch button span{grid-row:1/3;color:var(--gold);font-family:Orbitron,Montserrat,sans-serif;font-size:.7rem;padding-top:4px}
+.tx-mode-switch button strong{font:600 .98rem/1.35 Orbitron,Montserrat,sans-serif;color:var(--soft)}
+.tx-mode-switch button small{font-size:.74rem}
+.tx-mode-switch button[aria-selected=true]{background:linear-gradient(180deg,rgba(212,175,55,.11),rgba(212,175,55,.035));box-shadow:inset 0 -2px 0 var(--gold)}
+.tx-mode-switch button[aria-selected=true] strong{color:var(--pale)}
+.tx-mode-panel{display:grid;grid-template-columns:minmax(0,1.05fr) minmax(320px,.95fr);gap:42px;padding:38px;border:1px solid var(--line);border-top:0;border-radius:0 0 22px 22px;background:linear-gradient(180deg,rgba(16,21,31,.94),rgba(7,10,17,.96))}
+.tx-mode-panel h3{margin:0 0 14px;color:var(--pale);font-size:1.35rem}
+.tx-mode-panel p,.tx-mode-panel li{color:var(--soft)}
+.tx-mode-panel p{line-height:1.78;margin:0}
+.tx-mode-panel ol{margin:0;padding-left:22px}
+.tx-mode-panel li{margin:0 0 10px;padding-left:6px}
+.tx-usecases{grid-column:1/-1;display:flex;gap:9px;flex-wrap:wrap;padding-top:24px;border-top:1px solid rgba(255,255,255,.07)}
+.tx-usecases span{border:1px solid var(--line);border-radius:999px;padding:7px 11px;color:var(--muted);font-size:.72rem}
+.tx-control-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px}
+.tx-control{border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg,rgba(16,21,31,.92),rgba(7,10,17,.92));overflow:hidden}
+.tx-control summary{display:flex;align-items:center;gap:12px;padding:20px;cursor:pointer;list-style:none}
+.tx-control summary::-webkit-details-marker{display:none}
+.tx-control summary::after{content:"+";margin-left:auto;color:var(--gold);font-size:1.2rem}
+.tx-control[open] summary::after{content:"−"}
+.tx-control summary span{color:var(--gold);font:600 .65rem Orbitron,Montserrat,sans-serif}
+.tx-control summary strong{color:var(--pale);font-size:.92rem}
+.tx-control p{margin:0;padding:0 20px 22px;color:var(--soft);line-height:1.7;font-size:.9rem}
+.tx-doctrine{margin:32px 0 0;padding:26px 28px;border:1px solid rgba(212,175,55,.24);border-radius:18px;background:rgba(212,175,55,.055);color:var(--pale);font:500 clamp(1.05rem,2vw,1.45rem)/1.65 Montserrat,sans-serif}
+.tx-cycle{background:linear-gradient(180deg,rgba(212,175,55,.035),transparent)}
+.tx-cycle h2{max-width:900px}
+.tx-cycle-line{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:38px 0 20px}
+.tx-cycle-line span{padding:10px 13px;border:1px solid var(--line);border-radius:999px;color:var(--soft);background:rgba(8,11,18,.88);font-size:.78rem}
+.tx-cycle-line i{color:var(--gold);font-style:normal}
+.tx-cycle-note{color:var(--muted);max-width:880px;line-height:1.75}
+.tx-brand-chain{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:18px;align-items:stretch;margin-top:36px}
+.tx-brand-chain article{padding:26px;border:1px solid var(--line);border-radius:20px;background:linear-gradient(180deg,rgba(16,21,31,.94),rgba(7,10,17,.96))}
+.tx-brand-chain article span{color:var(--gold);font-size:.66rem;letter-spacing:.13em}
+.tx-brand-chain article h3{margin:12px 0;color:var(--pale);font-size:1.18rem}
+.tx-brand-chain article p{margin:0;color:var(--soft);line-height:1.7;font-size:.9rem}
+.tx-brand-chain>b{display:grid;place-items:center;color:var(--gold);font-size:1.5rem}
+.tx-integration-map{display:grid;grid-template-columns:minmax(240px,.9fr) auto minmax(220px,.7fr) auto minmax(240px,.9fr);gap:18px;align-items:center;margin-top:34px}
+.tx-source-stack,.tx-output-stack{display:grid;gap:8px}
+.tx-source-stack span,.tx-output-stack span{padding:12px 14px;border:1px solid var(--line);border-radius:12px;color:var(--soft);background:rgba(8,11,18,.82);font-size:.8rem}
+.tx-map-arrow{color:var(--gold);font-size:1.8rem;text-align:center}
+.tx-map-core{min-height:230px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid rgba(212,175,55,.42);background:radial-gradient(circle,rgba(212,175,55,.12),rgba(7,10,17,.98) 68%);box-shadow:0 0 70px rgba(212,175,55,.1)}
+.tx-map-core img{width:54px;height:54px;margin-bottom:12px}
+.tx-map-core strong{font:600 .8rem Orbitron,Montserrat,sans-serif;color:var(--pale);letter-spacing:.08em}
+.tx-map-core span{color:var(--muted);font-size:.7rem;margin-top:5px}
+.tx-app-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;margin-top:34px}
+.tx-app-grid article{padding:26px;border:1px solid var(--line);border-radius:20px;background:linear-gradient(180deg,rgba(16,21,31,.92),rgba(7,10,17,.94))}
+.tx-app-grid article span{color:var(--gold);font-size:.65rem;letter-spacing:.12em}
+.tx-app-grid h3{margin:12px 0;color:var(--pale);font-size:1.15rem}
+.tx-app-grid p{margin:0;color:var(--soft);line-height:1.72}
+.tx-landscape{background:linear-gradient(180deg,rgba(255,255,255,.012),transparent)}
+.tx-landscape-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.tx-landscape-grid details{border:1px solid var(--line);border-radius:16px;background:rgba(8,11,18,.84)}
+.tx-landscape-grid summary{cursor:pointer;list-style:none;padding:20px;color:var(--pale);font-weight:600}
+.tx-landscape-grid summary::-webkit-details-marker{display:none}
+.tx-landscape-grid summary::after{content:"+";float:right;color:var(--gold)}
+.tx-landscape-grid details[open] summary::after{content:"−"}
+.tx-landscape-grid p{margin:0;padding:0 20px 22px;color:var(--soft);line-height:1.7}
+.tx-landscape-note{margin:20px 0 0;color:var(--muted);font-size:.78rem}
+.tx-cta{padding:86px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.tx-cta-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,.45fr);gap:60px;align-items:center}
+.tx-cta h2{margin:16px 0;font-size:clamp(2.5rem,5vw,5.3rem);line-height:1.02;letter-spacing:-.04em}
+.tx-cta p{color:var(--soft);max-width:760px;line-height:1.75}
+.tx-cta-actions{display:flex;flex-direction:column;align-items:stretch;gap:12px}
+.tx-cta-actions .btn{width:100%}
+.tx-text-link{text-align:center;color:var(--pale);text-decoration:none;font-size:.85rem;padding:6px}
+.tx-text-link:hover{text-decoration:underline}
+.tx-cta-actions small{color:var(--muted);text-align:center;line-height:1.5}
+@keyframes txSpin{to{transform:translate(-50%,-50%) rotate(360deg)}}
+@keyframes txSpinReverse{to{transform:translate(-50%,-50%) rotate(-360deg)}}
+@media(max-width:1040px){
+  .tx-hero-grid,.tx-definition-grid,.tx-heading-row,.tx-cta-grid{grid-template-columns:1fr}
+  .tx-hero{min-height:auto}
+  .tx-visual{min-height:470px}
+  .tx-heading-row{gap:8px}
+  .tx-heading-row p{margin-bottom:0}
+  .tx-control-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .tx-integration-map{grid-template-columns:1fr}
+  .tx-map-arrow{transform:rotate(90deg)}
+  .tx-map-core{width:240px;height:240px;justify-self:center}
+}
+@media(max-width:760px){
+  .tx-hero{padding:64px 0 54px}
+  .tx-hero h1{font-size:clamp(2.55rem,13vw,4.4rem)}
+  .tx-visual{min-height:430px}
+  .tx-ring-a{width:330px;height:330px}
+  .tx-ring-b{width:245px;height:245px}
+  .tx-node{font-size:.54rem;padding:8px 10px}
+  .tx-node-2{right:-2%}.tx-node-5{left:-2%}
+  .tx-section{padding:66px 0}
+  .tx-mode-switch{grid-template-columns:1fr;border-radius:18px 18px 0 0}
+  .tx-mode-switch button{border-right:0;border-bottom:1px solid var(--line)}
+  .tx-mode-switch button:last-child{border-bottom:0}
+  .tx-mode-panel{grid-template-columns:1fr;padding:26px}
+  .tx-control-grid,.tx-app-grid,.tx-landscape-grid{grid-template-columns:1fr}
+  .tx-brand-chain{grid-template-columns:1fr}
+  .tx-brand-chain>b{transform:rotate(90deg);min-height:22px}
+  .tx-cycle-line{gap:7px}
+  .tx-cycle-line span{font-size:.7rem;padding:8px 10px}
+  .tx-cta h2{font-size:clamp(2.35rem,12vw,4.2rem)}
+}
+@media(max-width:500px){
+  .tx-visual{min-height:390px}
+  .tx-ring-a{width:285px;height:285px}
+  .tx-ring-b{width:210px;height:210px}
+  .tx-core{width:126px;height:126px}
+  .tx-node-1{top:3%}
+  .tx-node-3{bottom:8%;right:0}
+  .tx-node-4{bottom:4%;left:0}
+  .tx-crossline{gap:6px}
+  .tx-crossline span{font-size:.56rem}
+}
+@media(prefers-reduced-motion:reduce){
+  .tx-ring-a,.tx-ring-b{animation:none!important}
+}

--- a/docs/assets/truthx-engine.js
+++ b/docs/assets/truthx-engine.js
@@ -1,0 +1,34 @@
+(() => {
+  const tabs = [...document.querySelectorAll('[data-tx-mode]')];
+  const panels = [...document.querySelectorAll('[data-tx-panel]')];
+  if (!tabs.length || !panels.length) return;
+
+  const selectMode = mode => {
+    tabs.forEach(tab => {
+      const selected = tab.dataset.txMode === mode;
+      tab.setAttribute('aria-selected', selected ? 'true' : 'false');
+      tab.tabIndex = selected ? 0 : -1;
+    });
+    panels.forEach(panel => {
+      panel.hidden = panel.dataset.txPanel !== mode;
+    });
+  };
+
+  tabs.forEach((tab, index) => {
+    tab.addEventListener('click', () => selectMode(tab.dataset.txMode));
+    tab.addEventListener('keydown', event => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      let next = index;
+      if (event.key === 'ArrowRight') next = (index + 1) % tabs.length;
+      if (event.key === 'ArrowLeft') next = (index - 1 + tabs.length) % tabs.length;
+      if (event.key === 'Home') next = 0;
+      if (event.key === 'End') next = tabs.length - 1;
+      tabs[next].focus();
+      selectMode(tabs[next].dataset.txMode);
+    });
+  });
+
+  const hash = new URLSearchParams(window.location.search).get('mode');
+  if (hash && tabs.some(tab => tab.dataset.txMode === hash)) selectMode(hash);
+})();

--- a/docs/fr/truthx-engine/index.html
+++ b/docs/fr/truthx-engine/index.html
@@ -1,0 +1,369 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#050809">
+  <title>TruthX Engine — Intégrité factuelle, décisionnelle et probatoire | OpenProof</title>
+  <meta name="description" content="TruthX Engine reconstruit les situations passées et maintient la continuité vérifiable entre ce qui était attendu, déclaré, décidé, prouvé et livré.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <link rel="canonical" href="https://rpo.openproof.net/fr/truthx-engine/">
+  <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/truthx-engine/">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/truthx-engine/">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/truthx-engine/">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="OpenProof">
+  <meta property="og:title" content="TruthX Engine — Intégrité factuelle, décisionnelle et probatoire">
+  <meta property="og:description" content="Un moteur universel d’intégrité qui intervient avant, pendant et après le conflit.">
+  <meta property="og:url" content="https://rpo.openproof.net/fr/truthx-engine/">
+  <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:locale:alternate" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="TruthX Engine — Intégrité factuelle, décisionnelle et probatoire">
+  <meta name="twitter:description" content="Attendu × déclaré × décidé × prouvé × livré.">
+  <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "TruthX Engine — Moteur universel d’intégrité factuelle, décisionnelle et probatoire",
+    "description": "Doctrine publique d’un moteur universel qui reconstruit les situations passées et maintient une continuité vérifiable pendant l’exécution.",
+    "url": "https://rpo.openproof.net/fr/truthx-engine/",
+    "datePublished": "2026-08-05",
+    "dateModified": "2026-08-05",
+    "author": {
+      "@type": "Person",
+      "name": "Gersende de Parcey",
+      "url": "https://rpo.openproof.net/fr/gersende-de-parcey.html"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "about": [
+      "intégrité factuelle",
+      "intégrité décisionnelle",
+      "intégrité probatoire",
+      "traçabilité décisionnelle",
+      "intégrité continue des projets",
+      "reconstruction rétrospective",
+      "Registered Probative Object"
+    ],
+    "inLanguage": "fr"
+  }
+  </script>
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
+  <link rel="stylesheet" href="/assets/truthx-engine.css?v=20260805-1">
+</head>
+<body class="rpo-home truthx-engine-page">
+  <a class="skip" href="#main">Aller au contenu</a>
+
+  <nav class="nav" aria-label="Navigation principale">
+    <div class="wrap navin">
+      <a class="brand brand-lockup" href="/fr/">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
+        <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
+      </a>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
+      <div class="links">
+        <a href="/fr/">Spécification</a>
+        <a href="/fr/examples.html">Exemple</a>
+        <a href="/fr/tests.html">Vérifier</a>
+        <div class="truthx-nav" data-truthx-nav>
+          <a class="truthx-nav-main" href="/fr/truthx-engine/" aria-current="page">TruthX Engine</a>
+          <button class="truthx-nav-toggle" type="button" aria-expanded="false" aria-label="Ouvrir les sections TruthX Engine">⌄</button>
+          <div class="truthx-nav-menu">
+            <a href="/fr/truthx-engine/#overview">Vue d’ensemble</a>
+            <a href="/fr/truthx-engine/#modes">Deux modes d’intervention</a>
+            <a href="/fr/truthx-engine/#controls">Contrôles d’intégrité</a>
+            <a href="/fr/truthx-engine/#applications">Applications</a>
+            <a href="/fr/truthx-engine/#landscape">Paysage de recherche</a>
+          </div>
+        </div>
+        <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
+      <div class="language" aria-label="Langue">
+        <a href="/fr/truthx-engine/" lang="fr" hreflang="fr" aria-current="page">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/truthx-engine/" lang="en" hreflang="en">EN</a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <header class="tx-hero cosmos" id="overview">
+      <canvas class="stars" aria-hidden="true"></canvas>
+      <div class="wrap tx-hero-grid">
+        <div class="tx-hero-copy">
+          <p class="tx-eyebrow">TRUTHX ENGINE · DOCTRINE PUBLIQUE · V1</p>
+          <h1>Intégrité factuelle, décisionnelle et probatoire.<span>Avant, pendant et après le conflit.</span></h1>
+          <p class="tx-lead">TruthX Engine reconstruit les situations passées et maintient, pendant leur déroulement, la continuité vérifiable entre ce qui était attendu, déclaré, décidé, prouvé et finalement livré.</p>
+          <div class="tx-crossline" aria-label="Attendu, déclaré, décidé, prouvé et livré">
+            <span>ATTENDU</span><b>×</b><span>DÉCLARÉ</span><b>×</b><span>DÉCIDÉ</span><b>×</b><span>PROUVÉ</span><b>×</b><span>LIVRÉ</span>
+          </div>
+          <div class="tx-actions">
+            <a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas</a>
+            <a class="btn" href="https://app.openproof.net/">Explorer le laboratoire</a>
+          </div>
+          <p class="tx-safe">Décrivez le besoin, pas les preuves. Ne transmettez aucun document confidentiel à ce stade.</p>
+        </div>
+
+        <div class="tx-visual" aria-label="Croisement d’intégrité TruthX">
+          <div class="tx-ring tx-ring-a"></div>
+          <div class="tx-ring tx-ring-b"></div>
+          <div class="tx-core"><strong>TRUTH</strong><b>×</b><span>ENGINE</span></div>
+          <span class="tx-node tx-node-1">ATTENDU</span>
+          <span class="tx-node tx-node-2">DÉCLARÉ</span>
+          <span class="tx-node tx-node-3">DÉCIDÉ</span>
+          <span class="tx-node tx-node-4">PROUVÉ</span>
+          <span class="tx-node tx-node-5">LIVRÉ</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="tx-section tx-definition" aria-labelledby="definition-title">
+      <div class="wrap tx-definition-grid">
+        <div>
+          <p class="tx-index">01 · DÉFINITION</p>
+          <h2 id="definition-title">Le dossier probatoire ne devrait pas commencer lorsque le conflit éclate.</h2>
+        </div>
+        <div class="tx-copy">
+          <p>TruthX ne proclame pas une vérité absolue. Il organise les conditions permettant de déterminer ce que les sources étayent, ce qui reste contesté, ce qui manque et si l’exécution demeure cohérente avec les obligations et décisions enregistrées.</p>
+          <p>Le même moteur peut reconstruire une situation après l’échec ou maintenir son intégrité pendant qu’un projet avance encore. Le dossier probatoire devient un produit naturel de l’exécution responsable, plutôt qu’une reconstruction d’urgence plusieurs années plus tard.</p>
+          <div class="tx-boundary"><strong>Frontière publique.</strong> Cette page expose la finalité, le mode opératoire et les garanties. Les règles déterministes, l’orchestration, les seuils et l’implémentation privée restent confidentiels.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-modes" id="modes" aria-labelledby="modes-title">
+      <div class="wrap">
+        <p class="tx-index">02 · DEUX MODES D’INTERVENTION</p>
+        <div class="tx-heading-row">
+          <h2 id="modes-title">Un seul moteur. Deux moments d’intervention.</h2>
+          <p>Le moment change. La discipline d’intégrité demeure identique.</p>
+        </div>
+
+        <div class="tx-mode-switch" role="tablist" aria-label="Modes d’intervention de TruthX">
+          <button type="button" role="tab" aria-selected="true" aria-controls="mode-retrospective" id="tab-retrospective" data-tx-mode="retrospective">
+            <span>01</span><strong>Reconstruction rétrospective</strong><small>Après une crise, un conflit ou un échec</small>
+          </button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="mode-continuous" id="tab-continuous" data-tx-mode="continuous">
+            <span>02</span><strong>Intégrité continue</strong><small>Pendant que l’exécution peut encore être corrigée</small>
+          </button>
+        </div>
+
+        <div class="tx-mode-panel" id="mode-retrospective" role="tabpanel" aria-labelledby="tab-retrospective" data-tx-panel="retrospective">
+          <div>
+            <h3>Reconstruire ce qui s’est produit sans réécrire l’histoire.</h3>
+            <p>TruthX structure les sources fragmentées, les récits concurrents, la chronologie, les pouvoirs effectifs, les contradictions, les hypothèses et les mécanismes causaux. Les relecteurs humains décident de ce qui peut entrer dans le dossier revu.</p>
+          </div>
+          <ol>
+            <li>Collecter et préserver les sources</li>
+            <li>Séparer les déclarations des événements établis</li>
+            <li>Faire apparaître contradictions, lacunes et alternatives</li>
+            <li>Produire une base revue et vérifiable pour l’audit, la médiation ou le travail juridique</li>
+          </ol>
+          <div class="tx-usecases"><span>Legal Evidence</span><span>Investigation</span><span>Audit</span><span>Sinistres</span><span>Médiation</span></div>
+        </div>
+
+        <div class="tx-mode-panel" id="mode-continuous" role="tabpanel" aria-labelledby="tab-continuous" data-tx-panel="continuous" hidden>
+          <div>
+            <h3>Maintenir une exécution démontrable tant qu’elle est encore en mouvement.</h3>
+            <p>TruthX compare les obligations, jalons, déclarations, décisions, actions, corrections et preuves de livraison. Il identifie les incohérences assez tôt pour permettre à un humain responsable d’agir.</p>
+          </div>
+          <ol>
+            <li>Connecter les systèmes projet et opérationnels</li>
+            <li>Tester l’avancement déclaré contre les preuves et critères d’acceptation</li>
+            <li>Conserver décisions, désaccords et risques acceptés</li>
+            <li>Produire des instantanés RPO successifs au fil de l’évolution de la situation</li>
+          </ol>
+          <div class="tx-usecases"><span>Livraison de projets</span><span>Infrastructure</span><span>Transformation</span><span>Gouvernance</span><span>Conformité</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-controls" id="controls" aria-labelledby="controls-title">
+      <div class="wrap">
+        <p class="tx-index">03 · CONTRÔLES D’INTÉGRITÉ</p>
+        <div class="tx-heading-row">
+          <h2 id="controls-title">TruthX pilote la vérifiabilité — pas le métier des professionnels à leur place.</h2>
+          <p>Chaque contrôle demande si une représentation critique peut être démontrée et contestée.</p>
+        </div>
+        <div class="tx-control-grid">
+          <details class="tx-control" open>
+            <summary><span>01</span><strong>Déclarations</strong></summary>
+            <p>Qu’est-ce qui a été affirmé, par qui, quand, depuis quelle source et avec quelles limites ?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>02</span><strong>Jalons</strong></summary>
+            <p>Qu’est-ce qui devait être atteint, pour quelle date et selon quels critères d’acceptation ?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>03</span><strong>Décisions</strong></summary>
+            <p>Qui a décidé, à partir de quelles informations, options, validations et risques acceptés ?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>04</span><strong>Responsabilités</strong></summary>
+            <p>Qui devait agir, qui pouvait réellement agir et qui disposait du pouvoir de bloquer ou corriger ?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>05</span><strong>Corrections</strong></summary>
+            <p>Quelle remédiation a été demandée, promise, exécutée, vérifiée, refusée ou laissée sans réponse ?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>06</span><strong>Résultat</strong></summary>
+            <p>Qu’est-ce qui a finalement été livré et quelles preuves permettent de le comparer à l’attendu initial ?</p>
+          </details>
+        </div>
+        <blockquote class="tx-doctrine">TruthX ne gère pas le travail à la place des professionnels. Il garantit que ce qui est déclaré, décidé, modifié, corrigé et livré reste démontrable.</blockquote>
+      </div>
+    </section>
+
+    <section class="tx-section tx-cycle" aria-labelledby="cycle-title">
+      <div class="wrap">
+        <p class="tx-index">04 · DE LA CORRECTION AU CONTENTIEUX</p>
+        <h2 id="cycle-title">La trace sert d’abord la prévention. Le contentieux est son dernier usage possible.</h2>
+        <div class="tx-cycle-line" aria-label="Détection, correction, arbitrage, audit, assurance, médiation, défense, contentieux">
+          <span>Détection</span><i>→</i><span>Correction</span><i>→</i><span>Arbitrage</span><i>→</i><span>Audit</span><i>→</i><span>Assurance</span><i>→</i><span>Médiation</span><i>→</i><span>Défense</span><i>→</i><span>Contentieux</span>
+        </div>
+        <p class="tx-cycle-note">Une même base revue peut soutenir la remédiation précoce, la gouvernance, le traitement d’un sinistre et — seulement si nécessaire — un dossier de conflit défendable.</p>
+      </div>
+    </section>
+
+    <section class="tx-section tx-architecture" id="architecture" aria-labelledby="architecture-title">
+      <div class="wrap">
+        <p class="tx-index">05 · ARCHITECTURE PRODUIT</p>
+        <h2 id="architecture-title">Un moteur universel. Plusieurs applications professionnelles.</h2>
+        <div class="tx-brand-chain">
+          <article><span>LE MOTEUR</span><h3>TruthX Engine</h3><p>Structure et teste sources, attentes, décisions, actions, contradictions, causalités et résultats.</p></article>
+          <b>→</b>
+          <article><span>L’INFRASTRUCTURE</span><h3>OpenProof</h3><p>Fournit l’infrastructure probatoire, la frontière de revue et la couche publique de vérification.</p></article>
+          <b>→</b>
+          <article><span>L’OBJET</span><h3>RPO</h3><p>Conserve une représentation versionnée, sourcée, revue et indépendamment vérifiable.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-integrations" id="integrations" aria-labelledby="integrations-title">
+      <div class="wrap">
+        <p class="tx-index">06 · AU-DESSUS DES SYSTÈMES EXISTANTS</p>
+        <div class="tx-heading-row">
+          <h2 id="integrations-title">Connecter les outils. Ne pas enfermer toutes les équipes dans un nouveau monolithe.</h2>
+          <p>TruthX est conçu comme une couche indépendante d’intégrité au-dessus des systèmes opérationnels.</p>
+        </div>
+        <div class="tx-integration-map">
+          <div class="tx-source-stack">
+            <span>Planning et pilotage projet</span>
+            <span>ERP, coûts et achats</span>
+            <span>Contrats et obligations</span>
+            <span>Documents, BIM et terrain</span>
+            <span>Courriels, réunions et décisions</span>
+            <span>Inspections, incidents et OSINT</span>
+          </div>
+          <div class="tx-map-arrow">→</div>
+          <div class="tx-map-core"><img src="/assets/openproof-icon.svg?v=20260731-2" alt=""><strong>TRUTHX ENGINE</strong><span>intégrité inter-systèmes</span></div>
+          <div class="tx-map-arrow">→</div>
+          <div class="tx-output-stack">
+            <span>Contradictions et lacunes</span>
+            <span>Décisions à revoir</span>
+            <span>Risques et causes alternatives</span>
+            <span>Demandes de preuves</span>
+            <span>Instantanés RPO</span>
+          </div>
+        </div>
+        <blockquote class="tx-doctrine">Les outils métiers exécutent. Les plateformes projet coordonnent. TruthX vérifie, reconstruit, alerte et conserve la trace.</blockquote>
+      </div>
+    </section>
+
+    <section class="tx-section tx-applications" id="applications" aria-labelledby="applications-title">
+      <div class="wrap">
+        <p class="tx-index">07 · APPLICATIONS</p>
+        <h2 id="applications-title">Le langage professionnel change. Le noyau d’intégrité ne change pas.</h2>
+        <div class="tx-app-grid">
+          <article><span>01 · JURIDIQUE</span><h3>Legal Evidence Lab</h3><p>Reconstruire les faits, preuves, hypothèses concurrentes et lacunes afin que les professionnels du droit se concentrent sur le droit, la stratégie et la défense.</p></article>
+          <article><span>02 · LIVRAISON</span><h3>Project Delivery Integrity</h3><p>Relier exigences, jalons, dépendances, décisions, corrections et preuves de livraison sur les grands programmes.</p></article>
+          <article><span>03 · DÉFAUTS</span><h3>Defect &amp; Remediation Intelligence</h3><p>Tracer défauts, notifications, inspections, responsabilités, engagements de remédiation, vérification et exposition non résolue.</p></article>
+          <article><span>04 · EXTENSIONS</span><h3>Verticales futures</h3><p>Infrastructure, défense, industrie, santé, assurance, transformation numérique, conformité et programmes publics.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-landscape" id="landscape" aria-labelledby="landscape-title">
+      <div class="wrap">
+        <p class="tx-index">08 · PAYSAGE DE RECHERCHE</p>
+        <div class="tx-heading-row">
+          <h2 id="landscape-title">Les composants existent. La catégorie complète reste fragmentée.</h2>
+          <p>TruthX s’appuie sur des disciplines adjacentes sans prétendre avoir inventé la traçabilité, l’assurance ou la provenance.</p>
+        </div>
+        <div class="tx-landscape-grid">
+          <details open>
+            <summary>Ontologies opérationnelles et fils numériques</summary>
+            <p>Des plateformes relient déjà objets d’entreprise, actions et systèmes. TruthX ajoute une discipline native pour les connaissances contestées, les hypothèses concurrentes et la revue probatoire.</p>
+          </details>
+          <details>
+            <summary>Dossiers projet et assurance progressive</summary>
+            <p>Les outils de construction et d’infrastructure conservent déjà documents, exigences et preuves de conformité. TruthX cherche à comparer ce que les systèmes déclarent avec ce que les sources permettent réellement de démontrer.</p>
+          </details>
+          <details>
+            <summary>Investigation et reconstruction juridique</summary>
+            <p>Les plateformes d’eDiscovery et d’investigation reconstruisent les faits après les événements. TruthX combine ce mode rétrospectif avec des contrôles d’intégrité pendant que l’exécution est encore en cours.</p>
+          </details>
+          <details>
+            <summary>Position publique défendable</summary>
+            <p>Nous n’avons pas identifié de produit public unifiant reconstruction rétrospective, intégrité continue, états épistémiques explicites, pouvoir effectif, hypothèses causales concurrentes, OSINT, revue humaine et instantanés RPO portables dans une seule architecture native.</p>
+          </details>
+        </div>
+        <p class="tx-landscape-note">Cette formulation décrit un paysage produit public ; elle ne constitue ni un avis de brevetabilité ni une analyse exhaustive de liberté d’exploitation.</p>
+      </div>
+    </section>
+
+    <section class="tx-cta cosmos" id="pilot" aria-labelledby="pilot-title">
+      <canvas class="stars" aria-hidden="true"></canvas>
+      <div class="wrap tx-cta-grid">
+        <div>
+          <p class="tx-eyebrow">PILOTE · MISSION · PARTENARIAT</p>
+          <h2 id="pilot-title">Quelle situation doit rester démontrable ?</h2>
+          <p>Décrivez le projet, la décision, la crise ou le conflit. OpenProof qualifiera le périmètre avant tout paiement ou échange de preuves confidentielles.</p>
+        </div>
+        <div class="tx-cta-actions">
+          <a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas →</a>
+          <a class="btn" href="https://app.openproof.net/">Explorer le laboratoire</a>
+          <a class="tx-text-link" href="/fr/gersende-de-parcey.html#rpo-contact-form-fr">Recherche ou partenariat →</a>
+          <small>Ne transmettez aucun document confidentiel par un formulaire public.</small>
+        </div>
+      </div>
+    </section>
+
+    <section class="architecture-line" aria-label="Architecture de marque">
+      <div class="wrap">
+        <div><span>OPENPROOF</span><strong>Infrastructure probatoire</strong></div>
+        <b aria-hidden="true">→</b>
+        <div><span>TRUTHX ENGINE</span><strong>Moteur universel d’intégrité</strong></div>
+        <b aria-hidden="true">→</b>
+        <div><span>RPO</span><strong>Registered Probative Object</strong></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>TRUTHX ENGINE</strong><p>Doctrine publique maintenue par OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/fr/">Spécification RPO</a>
+        <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-1"></script>
+  <script src="/assets/truthx-engine.js?v=20260805-1"></script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,6 +20,24 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/"/>
   </url>
   <url>
+    <loc>https://rpo.openproof.net/truthx-engine/</loc>
+    <lastmod>2026-08-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/truthx-engine/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/truthx-engine/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/truthx-engine/"/>
+  </url>
+  <url>
+    <loc>https://rpo.openproof.net/fr/truthx-engine/</loc>
+    <lastmod>2026-08-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/truthx-engine/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/truthx-engine/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/truthx-engine/"/>
+  </url>
+  <url>
     <loc>https://rpo.openproof.net/examples.html</loc>
     <lastmod>2026-07-31</lastmod>
     <changefreq>monthly</changefreq>

--- a/docs/truthx-engine/index.html
+++ b/docs/truthx-engine/index.html
@@ -1,0 +1,369 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#050809">
+  <title>TruthX Engine — Factual, Decision and Probative Integrity | OpenProof</title>
+  <meta name="description" content="TruthX Engine reconstructs past situations and maintains verifiable continuity between what was expected, declared, decided, evidenced and delivered.">
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <link rel="canonical" href="https://rpo.openproof.net/truthx-engine/">
+  <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/truthx-engine/">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/truthx-engine/">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/truthx-engine/">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="OpenProof">
+  <meta property="og:title" content="TruthX Engine — Factual, Decision and Probative Integrity">
+  <meta property="og:description" content="A universal integrity engine operating before, during and after conflict.">
+  <meta property="og:url" content="https://rpo.openproof.net/truthx-engine/">
+  <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="TruthX Engine — Factual, Decision and Probative Integrity">
+  <meta name="twitter:description" content="Expected × declared × decided × evidenced × delivered.">
+  <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "TruthX Engine — Universal Factual, Decision and Probative Integrity",
+    "description": "Public doctrine for a universal engine that reconstructs past situations and maintains verifiable continuity during execution.",
+    "url": "https://rpo.openproof.net/truthx-engine/",
+    "datePublished": "2026-08-05",
+    "dateModified": "2026-08-05",
+    "author": {
+      "@type": "Person",
+      "name": "Gersende de Parcey",
+      "url": "https://rpo.openproof.net/gersende-de-parcey.html"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "about": [
+      "factual integrity",
+      "decision integrity",
+      "probative integrity",
+      "decision traceability",
+      "continuous project integrity",
+      "retrospective reconstruction",
+      "Registered Probative Object"
+    ],
+    "inLanguage": "en"
+  }
+  </script>
+  <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
+  <link rel="stylesheet" href="/assets/truthx-engine.css?v=20260805-1">
+</head>
+<body class="rpo-home truthx-engine-page">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="wrap navin">
+      <a class="brand brand-lockup" href="/">
+        <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
+        <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
+      </a>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Open menu">Menu</button>
+      <div class="links">
+        <a href="/">Specification</a>
+        <a href="/examples.html">Example</a>
+        <a href="/tests.html">Verify</a>
+        <div class="truthx-nav" data-truthx-nav>
+          <a class="truthx-nav-main" href="/truthx-engine/" aria-current="page">TruthX Engine</a>
+          <button class="truthx-nav-toggle" type="button" aria-expanded="false" aria-label="Open TruthX Engine sections">⌄</button>
+          <div class="truthx-nav-menu">
+            <a href="/truthx-engine/#overview">Overview</a>
+            <a href="/truthx-engine/#modes">Two operating modes</a>
+            <a href="/truthx-engine/#controls">Integrity controls</a>
+            <a href="/truthx-engine/#applications">Applications</a>
+            <a href="/truthx-engine/#landscape">Research landscape</a>
+          </div>
+        </div>
+        <a href="/gersende-de-parcey.html">Founder</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
+      <div class="language" aria-label="Language">
+        <a href="/fr/truthx-engine/" lang="fr" hreflang="fr">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/truthx-engine/" lang="en" hreflang="en" aria-current="page">EN</a>
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">
+    <header class="tx-hero cosmos" id="overview">
+      <canvas class="stars" aria-hidden="true"></canvas>
+      <div class="wrap tx-hero-grid">
+        <div class="tx-hero-copy">
+          <p class="tx-eyebrow">TRUTHX ENGINE · PUBLIC DOCTRINE · V1</p>
+          <h1>Factual, decision and probative integrity.<span>Before, during and after conflict.</span></h1>
+          <p class="tx-lead">TruthX Engine reconstructs past situations and maintains, during execution, the verifiable continuity between what was expected, declared, decided, evidenced and ultimately delivered.</p>
+          <div class="tx-crossline" aria-label="Expected, declared, decided, evidenced and delivered">
+            <span>EXPECTED</span><b>×</b><span>DECLARED</span><b>×</b><span>DECIDED</span><b>×</b><span>EVIDENCED</span><b>×</b><span>DELIVERED</span>
+          </div>
+          <div class="tx-actions">
+            <a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualify a case</a>
+            <a class="btn" href="https://app.openproof.net/">Explore the laboratory</a>
+          </div>
+          <p class="tx-safe">Describe the need, not the evidence. Do not submit confidential documents at this stage.</p>
+        </div>
+
+        <div class="tx-visual" aria-label="TruthX integrity cross">
+          <div class="tx-ring tx-ring-a"></div>
+          <div class="tx-ring tx-ring-b"></div>
+          <div class="tx-core"><strong>TRUTH</strong><b>×</b><span>ENGINE</span></div>
+          <span class="tx-node tx-node-1">EXPECTED</span>
+          <span class="tx-node tx-node-2">DECLARED</span>
+          <span class="tx-node tx-node-3">DECIDED</span>
+          <span class="tx-node tx-node-4">EVIDENCED</span>
+          <span class="tx-node tx-node-5">DELIVERED</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="tx-section tx-definition" aria-labelledby="definition-title">
+      <div class="wrap tx-definition-grid">
+        <div>
+          <p class="tx-index">01 · DEFINITION</p>
+          <h2 id="definition-title">A proof record should not begin when the conflict does.</h2>
+        </div>
+        <div class="tx-copy">
+          <p>TruthX does not declare an absolute truth. It organises the conditions required to determine what sources support, what remains contested, what is missing and whether execution remains coherent with recorded obligations and decisions.</p>
+          <p>The same engine can reconstruct a situation after failure or maintain integrity while a project is still moving. The probative record becomes a natural output of responsible execution rather than an emergency reconstruction years later.</p>
+          <div class="tx-boundary"><strong>Public boundary.</strong> This page explains the purpose, operating model and guarantees. The deterministic rules, orchestration, thresholds and private implementation remain confidential.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-modes" id="modes" aria-labelledby="modes-title">
+      <div class="wrap">
+        <p class="tx-index">02 · TWO OPERATING MODES</p>
+        <div class="tx-heading-row">
+          <h2 id="modes-title">One engine. Two moments of intervention.</h2>
+          <p>Choose the moment. The integrity discipline remains the same.</p>
+        </div>
+
+        <div class="tx-mode-switch" role="tablist" aria-label="TruthX operating modes">
+          <button type="button" role="tab" aria-selected="true" aria-controls="mode-retrospective" id="tab-retrospective" data-tx-mode="retrospective">
+            <span>01</span><strong>Retrospective reconstruction</strong><small>After a crisis, dispute or failure</small>
+          </button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="mode-continuous" id="tab-continuous" data-tx-mode="continuous">
+            <span>02</span><strong>Continuous integrity</strong><small>While execution can still be corrected</small>
+          </button>
+        </div>
+
+        <div class="tx-mode-panel" id="mode-retrospective" role="tabpanel" aria-labelledby="tab-retrospective" data-tx-panel="retrospective">
+          <div>
+            <h3>Reconstruct what happened without rewriting history.</h3>
+            <p>TruthX structures fragmented sources, competing narratives, chronology, effective powers, contradictions, hypotheses and causal mechanisms. Human reviewers decide what can enter the reviewed record.</p>
+          </div>
+          <ol>
+            <li>Collect and preserve sources</li>
+            <li>Separate statements from established events</li>
+            <li>Expose contradictions, gaps and alternatives</li>
+            <li>Produce a reviewed, verifiable basis for audit, mediation or legal work</li>
+          </ol>
+          <div class="tx-usecases"><span>Legal Evidence</span><span>Investigation</span><span>Audit</span><span>Insurance claims</span><span>Mediation</span></div>
+        </div>
+
+        <div class="tx-mode-panel" id="mode-continuous" role="tabpanel" aria-labelledby="tab-continuous" data-tx-panel="continuous" hidden>
+          <div>
+            <h3>Keep execution demonstrable while it is still in motion.</h3>
+            <p>TruthX compares obligations, milestones, declarations, decisions, actions, corrections and evidence of delivery. It identifies incoherence early enough for a responsible human to act.</p>
+          </div>
+          <ol>
+            <li>Connect project and operational systems</li>
+            <li>Test declared progress against evidence and acceptance criteria</li>
+            <li>Preserve decisions, dissent and accepted risks</li>
+            <li>Generate successive RPO snapshots as the situation evolves</li>
+          </ol>
+          <div class="tx-usecases"><span>Project delivery</span><span>Infrastructure</span><span>Transformation</span><span>Governance</span><span>Compliance</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-controls" id="controls" aria-labelledby="controls-title">
+      <div class="wrap">
+        <p class="tx-index">03 · INTEGRITY CONTROLS</p>
+        <div class="tx-heading-row">
+          <h2 id="controls-title">TruthX pilots verifiability — not the professional work itself.</h2>
+          <p>Each control asks whether a critical representation can be demonstrated and challenged.</p>
+        </div>
+        <div class="tx-control-grid">
+          <details class="tx-control" open>
+            <summary><span>01</span><strong>Declarations</strong></summary>
+            <p>What was asserted, by whom, when, from which source and with which limits?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>02</span><strong>Milestones</strong></summary>
+            <p>What was expected, by which date and according to which acceptance criteria?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>03</span><strong>Decisions</strong></summary>
+            <p>Who decided, using which information, options, validations and accepted risks?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>04</span><strong>Responsibilities</strong></summary>
+            <p>Who was required to act, who could actually act and who had the power to block or correct?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>05</span><strong>Corrections</strong></summary>
+            <p>What remediation was requested, promised, executed, verified, refused or left unanswered?</p>
+          </details>
+          <details class="tx-control">
+            <summary><span>06</span><strong>Outcome</strong></summary>
+            <p>What was ultimately delivered, and which evidence supports comparison with the original expectation?</p>
+          </details>
+        </div>
+        <blockquote class="tx-doctrine">TruthX does not manage the work on behalf of professionals. It ensures that what is declared, decided, changed, corrected and delivered remains demonstrable.</blockquote>
+      </div>
+    </section>
+
+    <section class="tx-section tx-cycle" aria-labelledby="cycle-title">
+      <div class="wrap">
+        <p class="tx-index">04 · FROM CORRECTION TO CONTENTION</p>
+        <h2 id="cycle-title">The record serves prevention first. Litigation is the last possible use.</h2>
+        <div class="tx-cycle-line" aria-label="Detection, correction, arbitration, audit, insurance, mediation, defence, litigation">
+          <span>Detection</span><i>→</i><span>Correction</span><i>→</i><span>Arbitration</span><i>→</i><span>Audit</span><i>→</i><span>Insurance</span><i>→</i><span>Mediation</span><i>→</i><span>Defence</span><i>→</i><span>Litigation</span>
+        </div>
+        <p class="tx-cycle-note">A single reviewed basis can support early remediation, governance, claims handling and — only if necessary — a defensible dispute record.</p>
+      </div>
+    </section>
+
+    <section class="tx-section tx-architecture" id="architecture" aria-labelledby="architecture-title">
+      <div class="wrap">
+        <p class="tx-index">05 · PRODUCT ARCHITECTURE</p>
+        <h2 id="architecture-title">One universal engine. Several professional applications.</h2>
+        <div class="tx-brand-chain">
+          <article><span>THE ENGINE</span><h3>TruthX Engine</h3><p>Structures and tests sources, expectations, decisions, actions, contradictions, causalities and outcomes.</p></article>
+          <b>→</b>
+          <article><span>THE INFRASTRUCTURE</span><h3>OpenProof</h3><p>Provides the probative infrastructure, review boundary and public verification layer.</p></article>
+          <b>→</b>
+          <article><span>THE OBJECT</span><h3>RPO</h3><p>Preserves a versioned, sourced, reviewed and independently verifiable record.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-integrations" id="integrations" aria-labelledby="integrations-title">
+      <div class="wrap">
+        <p class="tx-index">06 · ABOVE EXISTING SYSTEMS</p>
+        <div class="tx-heading-row">
+          <h2 id="integrations-title">Connect the tools. Do not force every team into another monolith.</h2>
+          <p>TruthX is designed as an independent integrity layer above operational systems.</p>
+        </div>
+        <div class="tx-integration-map">
+          <div class="tx-source-stack">
+            <span>Planning &amp; project controls</span>
+            <span>ERP, costs &amp; procurement</span>
+            <span>Contracts &amp; obligations</span>
+            <span>Documents, BIM &amp; field tools</span>
+            <span>Email, meetings &amp; decisions</span>
+            <span>Inspections, incidents &amp; OSINT</span>
+          </div>
+          <div class="tx-map-arrow">→</div>
+          <div class="tx-map-core"><img src="/assets/openproof-icon.svg?v=20260731-2" alt=""><strong>TRUTHX ENGINE</strong><span>cross-system integrity</span></div>
+          <div class="tx-map-arrow">→</div>
+          <div class="tx-output-stack">
+            <span>Contradictions &amp; gaps</span>
+            <span>Decisions requiring review</span>
+            <span>Risks and causal alternatives</span>
+            <span>Evidence requests</span>
+            <span>RPO snapshots</span>
+          </div>
+        </div>
+        <blockquote class="tx-doctrine">Operational tools execute. Project platforms coordinate. TruthX verifies, reconstructs, alerts and preserves the trace.</blockquote>
+      </div>
+    </section>
+
+    <section class="tx-section tx-applications" id="applications" aria-labelledby="applications-title">
+      <div class="wrap">
+        <p class="tx-index">07 · APPLICATIONS</p>
+        <h2 id="applications-title">The professional language changes. The integrity core does not.</h2>
+        <div class="tx-app-grid">
+          <article><span>01 · LEGAL</span><h3>Legal Evidence Lab</h3><p>Reconstruct facts, evidence, competing hypotheses and gaps so legal professionals can focus on law, strategy and defence.</p></article>
+          <article><span>02 · DELIVERY</span><h3>Project Delivery Integrity</h3><p>Connect requirements, milestones, dependencies, decisions, corrections and evidence of delivery across major programmes.</p></article>
+          <article><span>03 · DEFECTS</span><h3>Defect &amp; Remediation Intelligence</h3><p>Trace defects, notices, inspections, responsibilities, remediation promises, verification and unresolved exposure.</p></article>
+          <article><span>04 · EXTENSIONS</span><h3>Future verticals</h3><p>Infrastructure, defence, industry, health, insurance, digital transformation, compliance and public programmes.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="tx-section tx-landscape" id="landscape" aria-labelledby="landscape-title">
+      <div class="wrap">
+        <p class="tx-index">08 · RESEARCH LANDSCAPE</p>
+        <div class="tx-heading-row">
+          <h2 id="landscape-title">The components exist. The complete category remains fragmented.</h2>
+          <p>TruthX is informed by adjacent disciplines without claiming to have invented traceability, assurance or provenance.</p>
+        </div>
+        <div class="tx-landscape-grid">
+          <details open>
+            <summary>Operational ontology and digital threads</summary>
+            <p>Platforms already connect enterprise objects, actions and systems. TruthX adds a native discipline for contested knowledge, competing hypotheses and probative review.</p>
+          </details>
+          <details>
+            <summary>Project records and progressive assurance</summary>
+            <p>Construction and infrastructure tools already preserve documents, requirements and compliance evidence. TruthX aims to compare what systems declare with what sources can actually demonstrate.</p>
+          </details>
+          <details>
+            <summary>Investigation and legal reconstruction</summary>
+            <p>eDiscovery and investigation platforms reconstruct facts after the event. TruthX combines that retrospective capability with integrity controls while execution is still underway.</p>
+          </details>
+          <details>
+            <summary>Publicly defensible position</summary>
+            <p>We have not identified a public product unifying retrospective reconstruction, continuous integrity, explicit epistemic states, effective power, competing causal hypotheses, OSINT, human review and portable RPO snapshots as one native architecture.</p>
+          </details>
+        </div>
+        <p class="tx-landscape-note">This is a public product landscape statement, not a patentability opinion or exhaustive freedom-to-operate analysis.</p>
+      </div>
+    </section>
+
+    <section class="tx-cta cosmos" id="pilot" aria-labelledby="pilot-title">
+      <canvas class="stars" aria-hidden="true"></canvas>
+      <div class="wrap tx-cta-grid">
+        <div>
+          <p class="tx-eyebrow">PILOT · MISSION · PARTNERSHIP</p>
+          <h2 id="pilot-title">What must remain demonstrable?</h2>
+          <p>Describe the project, decision, crisis or dispute. OpenProof will qualify the perimeter before any payment or confidential evidence exchange.</p>
+        </div>
+        <div class="tx-cta-actions">
+          <a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualify a case →</a>
+          <a class="btn" href="https://app.openproof.net/">Explore the laboratory</a>
+          <a class="tx-text-link" href="/gersende-de-parcey.html#rpo-contact-form-en">Research or partnership →</a>
+          <small>Do not submit confidential documents through a public form.</small>
+        </div>
+      </div>
+    </section>
+
+    <section class="architecture-line" aria-label="Brand architecture">
+      <div class="wrap">
+        <div><span>OPENPROOF</span><strong>Probative infrastructure</strong></div>
+        <b aria-hidden="true">→</b>
+        <div><span>TRUTHX ENGINE</span><strong>Universal integrity engine</strong></div>
+        <b aria-hidden="true">→</b>
+        <div><span>RPO</span><strong>Registered probative object</strong></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>TRUTHX ENGINE</strong><p>Public doctrine maintained by OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/">RPO Specification</a>
+        <a href="/gersende-de-parcey.html">Founder</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-1"></script>
+  <script src="/assets/truthx-engine.js?v=20260805-1"></script>
+</body>
+</html>


### PR DESCRIPTION
## What changed

- adds a bilingual public TruthX Engine page at `/truthx-engine/` and `/fr/truthx-engine/`
- preserves the existing OpenProof/RPO visual system: Orbitron, Montserrat, black/ivory/gold palette, cosmic field, responsive cards and reduced-motion support
- explains the canonical doctrine without exposing private implementation details:
  - factual, decision and probative integrity
  - retrospective reconstruction and continuous integrity
  - declaration, milestone, decision, responsibility, correction and outcome controls
  - the correction → audit → insurance → mediation → defence → litigation continuum
  - TruthX Engine → OpenProof → RPO architecture
  - positioning above existing project and operational tools
  - legal, delivery and defect/remediation applications
- adds the approved CTAs:
  - `Qualify a case` → `https://app.openproof.net/qualify?intent=case`
  - `Explore the laboratory` → `https://app.openproof.net/`
  - research/partnership → founder contact section
- injects a lightweight bilingual TruthX Engine dropdown into the existing navigation without rewriting every static page
- adds canonical, hreflang, Open Graph, Twitter and `TechArticle` structured metadata
- adds both URLs to the sitemap

## Public/private boundary

The page publishes the category, doctrine, use cases and guarantees. It does not expose deterministic rules, module orchestration, thresholds, prompts, security design or private engine contracts.

## Validation performed

- EN/FR HTML parsed successfully
- JSON-LD parsed successfully
- duplicate IDs checked
- JavaScript syntax checked with Node
- CSS brace balance checked
- bilingual section parity checked
- branch is 6 commits ahead of `main`, with no unrelated changes
