### PR TITLE
Align TruthX Engine page with the canonical OpenProof charter

### DIFF
--- a/docs/assets/truthx-engine.css
+++ b/docs/assets/truthx-engine.css
@@ -1,115 +1,149 @@
-.truthx-engine-page{background:#04050a}
+/* TruthX Engine public page — aligned with the canonical OpenProof / RPO visual system */
+.truthx-engine-page{background:#050709;color:var(--ink)}
 .truthx-engine-page h1,.truthx-engine-page h2,.truthx-engine-page h3,.truthx-engine-page .tx-index,.truthx-engine-page .tx-eyebrow,.truthx-engine-page .tx-crossline,.truthx-engine-page .tx-core,.truthx-engine-page .tx-node{font-family:Orbitron,Montserrat,sans-serif}
 .truthx-engine-page p,.truthx-engine-page li,.truthx-engine-page summary,.truthx-engine-page small{font-family:Montserrat,Inter,ui-sans-serif,system-ui,sans-serif}
-.tx-hero{padding:88px 0 76px;min-height:760px;display:flex;align-items:center}
-.tx-hero-grid{display:grid;grid-template-columns:minmax(0,1.08fr) minmax(390px,.92fr);gap:56px;align-items:center}
-.tx-eyebrow,.tx-index{margin:0;color:var(--pale);font-size:.69rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase}
-.tx-hero h1{font-size:clamp(3rem,6vw,6.4rem);line-height:.97;letter-spacing:-.045em;margin:20px 0 24px;max-width:930px}
-.tx-hero h1 span{display:block;margin-top:14px;color:var(--gold);font-size:.46em;line-height:1.2;letter-spacing:-.015em}
-.tx-lead{max-width:820px;margin:0;color:var(--soft);font-size:clamp(1.02rem,1.65vw,1.28rem);line-height:1.8}
-.tx-crossline{display:flex;align-items:center;flex-wrap:wrap;gap:9px;margin:30px 0 0;color:var(--muted);font-size:.63rem;letter-spacing:.12em}
-.tx-crossline b{color:var(--gold);font-size:1.35rem;font-weight:500}
-.tx-actions{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-top:30px}
-.tx-safe{margin:13px 0 0;color:var(--muted);font-size:.78rem}
-.tx-visual{position:relative;min-height:520px;display:grid;place-items:center}
-.tx-ring{position:absolute;border-radius:50%;left:50%;top:50%;transform:translate(-50%,-50%)}
-.tx-ring-a{width:430px;height:430px;border:1px solid rgba(212,175,55,.28);box-shadow:0 0 60px rgba(212,175,55,.05);animation:txSpin 34s linear infinite}
-.tx-ring-b{width:320px;height:320px;border:1px dashed rgba(241,230,163,.18);animation:txSpinReverse 25s linear infinite}
-.tx-ring-a::before,.tx-ring-b::before{content:"";position:absolute;inset:10%;border-radius:50%;border:1px solid rgba(93,115,255,.14)}
-.tx-core{width:148px;height:148px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid rgba(212,175,55,.52);background:radial-gradient(circle,rgba(241,230,163,.18),rgba(212,175,55,.06) 45%,rgba(2,4,11,.96) 73%);box-shadow:0 0 0 18px rgba(212,175,55,.025),0 0 90px rgba(212,175,55,.22)}
-.tx-core strong{color:var(--pale);font-size:.86rem;letter-spacing:.16em}
-.tx-core b{color:var(--gold);font-size:2.1rem;line-height:1}
-.tx-core span{color:var(--muted);font-size:.6rem;letter-spacing:.17em}
-.tx-node{position:absolute;padding:10px 13px;border:1px solid var(--line);border-radius:999px;background:rgba(6,9,16,.92);box-shadow:0 12px 32px rgba(0,0,0,.38);color:var(--soft);font-size:.62rem;letter-spacing:.1em;white-space:nowrap}
-.tx-node-1{top:5%;left:44%;transform:translateX(-50%)}
-.tx-node-2{top:26%;right:0}
-.tx-node-3{bottom:12%;right:7%}
-.tx-node-4{bottom:7%;left:4%}
-.tx-node-5{top:24%;left:0}
-.tx-section{padding:88px 0;border-top:1px solid var(--line)}
-.tx-section h2{font-size:clamp(2.1rem,4vw,4.5rem);line-height:1.08;letter-spacing:-.035em;margin:16px 0;color:var(--ink)}
-.tx-definition{background:linear-gradient(180deg,rgba(255,255,255,.015),transparent)}
-.tx-definition-grid{display:grid;grid-template-columns:minmax(0,.9fr) minmax(360px,1.1fr);gap:78px;align-items:start}
-.tx-copy p{margin:0 0 22px;color:var(--soft);font-size:1.02rem;line-height:1.85}
-.tx-boundary{margin-top:30px;padding:20px 22px;border-left:3px solid var(--gold);background:rgba(212,175,55,.07);border-radius:0 16px 16px 0;color:var(--soft)}
+
+/* Editorial body copy is justified, while labels, navigation and buttons remain naturally aligned. */
+.tx-lead,.tx-copy p,.tx-boundary,.tx-heading-row>p,.tx-mode-panel p,.tx-mode-panel li,.tx-control p,.tx-doctrine,.tx-cycle-note,.tx-brand-chain article p,.tx-app-grid article p,.tx-landscape-grid details p,.tx-landscape-note,.tx-cta-grid>div>p:not(.tx-eyebrow){text-align:justify;text-align-last:left;text-justify:inter-word;hyphens:auto;-webkit-hyphens:auto}
+
+/* Hero: same edge-to-edge field, scale and rhythm as the RPO homepage and verification page. */
+.tx-hero{min-height:790px;padding:0;display:flex;align-items:stretch}
+.tx-hero-grid{width:100%;max-width:none;min-height:790px;margin:0;padding:92px 6vw 112px;display:grid;grid-template-columns:minmax(550px,1fr) minmax(520px,.82fr);gap:4vw;align-items:center}
+.tx-eyebrow,.tx-index{margin:0;color:var(--gold);font-size:7px;font-weight:700;letter-spacing:2.2px;text-transform:uppercase}
+.tx-hero h1{max-width:820px;margin:23px 0 31px;color:#ece8df;font:500 clamp(51px,5.2vw,78px)/.98 Orbitron,Montserrat,sans-serif;letter-spacing:-.035em;text-transform:uppercase;text-shadow:0 4px 35px #000}
+.tx-hero h1 span{display:block;margin-top:18px;color:var(--gold);font-size:.49em;line-height:1.16;letter-spacing:-.02em}
+.tx-lead{max-width:630px;margin:0;color:#9ca4a5;font-size:14px;line-height:1.85;letter-spacing:.15px}
+.tx-crossline{display:flex;align-items:center;flex-wrap:wrap;gap:8px;margin:31px 0 0;color:#70797d;font-size:7px;letter-spacing:1.25px}
+.tx-crossline b{color:var(--gold);font-size:1rem;font-weight:500}
+.tx-actions{display:flex;align-items:center;gap:28px;flex-wrap:wrap;margin-top:38px}
+.tx-safe{max-width:630px;margin:14px 0 0;color:#70797d;font-size:8px;line-height:1.6;letter-spacing:.2px}
+
+/* Hero integrity object: same warm metal / steel language as the public RPO object. */
+.tx-visual{position:relative;width:100%;max-width:570px;min-height:570px;display:grid;place-items:center;justify-self:end}
+.tx-visual::before{content:"";position:absolute;inset:13%;border-radius:50%;background:radial-gradient(circle,rgba(214,179,106,.09),rgba(100,117,128,.05) 30%,transparent 68%);filter:blur(2px)}
+.tx-ring{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);border-radius:50%}
+.tx-ring-a{width:53%;height:53%;border:1px solid rgba(172,154,112,.26);box-shadow:none;animation:txSpin 34s linear infinite}
+.tx-ring-b{width:76%;height:76%;border:1px solid rgba(172,154,112,.20);animation:txSpinReverse 25s linear infinite}
+.tx-ring-a::before,.tx-ring-b::before{content:"";position:absolute;border-radius:50%;pointer-events:none}
+.tx-ring-a::before{inset:-43%;border:1px solid rgba(133,150,156,.14)}
+.tx-ring-b::before{inset:14%;border:1px solid rgba(172,154,112,.12)}
+.tx-core{position:relative;width:170px;height:170px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid #d8bc7b;background:radial-gradient(circle at 48% 42%,#283038,#0a0e12 63%);box-shadow:inset 0 0 45px rgba(210,174,96,.15),0 0 70px rgba(177,140,70,.12),0 0 0 12px rgba(185,155,92,.04)}
+.tx-core strong{color:#e2c98e;font-size:.78rem;letter-spacing:.16em}
+.tx-core b{color:var(--gold);font-size:2rem;line-height:1.05}
+.tx-core span{color:#70797d;font-size:.54rem;letter-spacing:.17em}
+.tx-node{position:absolute;padding:0 0 0 12px;border:0;border-radius:0;background:transparent;box-shadow:none;color:#70797d;font-size:7px;letter-spacing:1.35px;white-space:nowrap}
+.tx-node::before{content:"";position:absolute;left:0;top:50%;width:5px;height:5px;border-radius:50%;transform:translateY(-50%);background:#c7a65f;box-shadow:0 0 10px #d5af60}
+.tx-node-1{top:17%;left:47%;transform:translateX(-50%)}
+.tx-node-2{top:30%;right:0}
+.tx-node-3{bottom:20%;right:7%}
+.tx-node-4{bottom:17%;left:7%}
+.tx-node-5{top:31%;left:0}
+
+/* Shared lower-page structure. */
+.tx-section{padding:105px 0;border-top:1px solid var(--line)}
+.tx-section>.wrap,.tx-cta>.wrap{width:min(1240px,calc(100% - 12vw));margin:auto}
+.tx-section h2{margin:16px 0;color:#ece8df;font:500 clamp(2.1rem,3.6vw,3.9rem)/1.1 Orbitron,Montserrat,sans-serif;letter-spacing:-.025em}
+.tx-definition,.tx-controls,.tx-architecture,.tx-applications{background:#080b0f}
+.tx-modes,.tx-cycle,.tx-integrations,.tx-landscape{background:#0d1217}
+.tx-definition-grid{display:grid;grid-template-columns:minmax(0,.92fr) minmax(420px,1.08fr);gap:96px;align-items:start}
+.tx-copy p{margin:0 0 22px;color:#9da6aa;font-size:.94rem;line-height:1.9}
+.tx-boundary{margin-top:30px;padding:20px 22px;border-left:2px solid var(--gold);border-radius:0;background:rgba(196,154,88,.055);color:#9da6aa;font-size:.9rem;line-height:1.75}
 .tx-boundary strong{color:var(--pale)}
-.tx-heading-row{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,.42fr);gap:50px;align-items:end;margin-bottom:34px}
-.tx-heading-row p{color:var(--muted);margin:0 0 22px;line-height:1.75}
-.tx-mode-switch{display:grid;grid-template-columns:1fr 1fr;border:1px solid var(--line);border-radius:22px 22px 0 0;overflow:hidden;background:rgba(7,10,17,.7)}
-.tx-mode-switch button{display:grid;grid-template-columns:auto 1fr;grid-template-rows:auto auto;gap:2px 14px;text-align:left;padding:24px 26px;border:0;border-right:1px solid var(--line);background:transparent;color:var(--muted);cursor:pointer}
+.tx-heading-row{display:grid;grid-template-columns:minmax(0,1fr) minmax(300px,.42fr);gap:62px;align-items:end;margin-bottom:38px}
+.tx-heading-row p{margin:0 0 20px;color:var(--muted);font-size:.9rem;line-height:1.8}
+
+/* Modes. */
+.tx-mode-switch{display:grid;grid-template-columns:1fr 1fr;border:1px solid var(--line);border-radius:0;overflow:hidden;background:#080b0f}
+.tx-mode-switch button{display:grid;grid-template-columns:auto 1fr;grid-template-rows:auto auto;gap:2px 14px;text-align:left;padding:25px 28px;border:0;border-right:1px solid var(--line);background:transparent;color:var(--muted);cursor:pointer}
 .tx-mode-switch button:last-child{border-right:0}
-.tx-mode-switch button span{grid-row:1/3;color:var(--gold);font-family:Orbitron,Montserrat,sans-serif;font-size:.7rem;padding-top:4px}
-.tx-mode-switch button strong{font:600 .98rem/1.35 Orbitron,Montserrat,sans-serif;color:var(--soft)}
-.tx-mode-switch button small{font-size:.74rem}
-.tx-mode-switch button[aria-selected=true]{background:linear-gradient(180deg,rgba(212,175,55,.11),rgba(212,175,55,.035));box-shadow:inset 0 -2px 0 var(--gold)}
+.tx-mode-switch button span{grid-row:1/3;color:var(--gold);font:600 .64rem Orbitron,Montserrat,sans-serif;padding-top:4px}
+.tx-mode-switch button strong{color:var(--soft);font:600 .91rem/1.4 Orbitron,Montserrat,sans-serif;letter-spacing:.02em}
+.tx-mode-switch button small{font-size:.72rem;line-height:1.5}
+.tx-mode-switch button[aria-selected=true]{background:linear-gradient(180deg,rgba(196,154,88,.10),rgba(196,154,88,.025));box-shadow:inset 0 -2px 0 var(--gold)}
 .tx-mode-switch button[aria-selected=true] strong{color:var(--pale)}
-.tx-mode-panel{display:grid;grid-template-columns:minmax(0,1.05fr) minmax(320px,.95fr);gap:42px;padding:38px;border:1px solid var(--line);border-top:0;border-radius:0 0 22px 22px;background:linear-gradient(180deg,rgba(16,21,31,.94),rgba(7,10,17,.96))}
-.tx-mode-panel h3{margin:0 0 14px;color:var(--pale);font-size:1.35rem}
-.tx-mode-panel p,.tx-mode-panel li{color:var(--soft)}
-.tx-mode-panel p{line-height:1.78;margin:0}
+.tx-mode-panel{display:grid;grid-template-columns:minmax(0,1.05fr) minmax(320px,.95fr);gap:50px;padding:40px;border:1px solid var(--line);border-top:0;border-radius:0;background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.98))}
+.tx-mode-panel h3{margin:0 0 15px;color:var(--pale);font:600 1.12rem/1.45 Orbitron,Montserrat,sans-serif;letter-spacing:.02em}
+.tx-mode-panel p,.tx-mode-panel li{color:#9da6aa;font-size:.9rem}
+.tx-mode-panel p{margin:0;line-height:1.82}
 .tx-mode-panel ol{margin:0;padding-left:22px}
-.tx-mode-panel li{margin:0 0 10px;padding-left:6px}
-.tx-usecases{grid-column:1/-1;display:flex;gap:9px;flex-wrap:wrap;padding-top:24px;border-top:1px solid rgba(255,255,255,.07)}
-.tx-usecases span{border:1px solid var(--line);border-radius:999px;padding:7px 11px;color:var(--muted);font-size:.72rem}
+.tx-mode-panel li{margin:0 0 11px;padding-left:6px;line-height:1.65}
+.tx-usecases{grid-column:1/-1;display:flex;gap:0;flex-wrap:wrap;padding-top:25px;border-top:1px solid rgba(255,255,255,.07)}
+.tx-usecases span{padding:7px 13px;border:0;border-right:1px solid var(--line);border-radius:0;color:var(--muted);font-size:.68rem;letter-spacing:.03em}
+.tx-usecases span:first-child{padding-left:0}
+.tx-usecases span:last-child{border-right:0}
+
+/* Integrity controls. */
 .tx-control-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:16px}
-.tx-control{border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg,rgba(16,21,31,.92),rgba(7,10,17,.92));overflow:hidden}
-.tx-control summary{display:flex;align-items:center;gap:12px;padding:20px;cursor:pointer;list-style:none}
+.tx-control{border:1px solid var(--line);border-radius:0;background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96));overflow:hidden}
+.tx-control summary{display:flex;align-items:center;gap:12px;padding:21px;cursor:pointer;list-style:none}
 .tx-control summary::-webkit-details-marker{display:none}
-.tx-control summary::after{content:"+";margin-left:auto;color:var(--gold);font-size:1.2rem}
+.tx-control summary::after{content:"+";margin-left:auto;color:var(--gold);font-size:1.1rem}
 .tx-control[open] summary::after{content:"−"}
-.tx-control summary span{color:var(--gold);font:600 .65rem Orbitron,Montserrat,sans-serif}
-.tx-control summary strong{color:var(--pale);font-size:.92rem}
-.tx-control p{margin:0;padding:0 20px 22px;color:var(--soft);line-height:1.7;font-size:.9rem}
-.tx-doctrine{margin:32px 0 0;padding:26px 28px;border:1px solid rgba(212,175,55,.24);border-radius:18px;background:rgba(212,175,55,.055);color:var(--pale);font:500 clamp(1.05rem,2vw,1.45rem)/1.65 Montserrat,sans-serif}
-.tx-cycle{background:linear-gradient(180deg,rgba(212,175,55,.035),transparent)}
+.tx-control summary span{color:var(--gold);font:600 .62rem Orbitron,Montserrat,sans-serif}
+.tx-control summary strong{color:var(--pale);font-size:.88rem;letter-spacing:.02em}
+.tx-control p{margin:0;padding:0 21px 23px;color:#9da6aa;font-size:.84rem;line-height:1.75}
+.tx-doctrine{margin:34px 0 0;padding:26px 28px;border:1px solid rgba(196,154,88,.25);border-radius:0;background:rgba(196,154,88,.045);color:var(--pale);font:500 clamp(1rem,1.75vw,1.3rem)/1.7 Montserrat,sans-serif}
+
+/* Correction-to-litigation continuum. */
 .tx-cycle h2{max-width:900px}
-.tx-cycle-line{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:38px 0 20px}
-.tx-cycle-line span{padding:10px 13px;border:1px solid var(--line);border-radius:999px;color:var(--soft);background:rgba(8,11,18,.88);font-size:.78rem}
+.tx-cycle-line{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:40px 0 22px}
+.tx-cycle-line span{padding:10px 13px;border:1px solid var(--line);border-radius:0;color:#9da6aa;background:#080b0f;font-size:.72rem;letter-spacing:.03em}
 .tx-cycle-line i{color:var(--gold);font-style:normal}
-.tx-cycle-note{color:var(--muted);max-width:880px;line-height:1.75}
-.tx-brand-chain{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:18px;align-items:stretch;margin-top:36px}
-.tx-brand-chain article{padding:26px;border:1px solid var(--line);border-radius:20px;background:linear-gradient(180deg,rgba(16,21,31,.94),rgba(7,10,17,.96))}
-.tx-brand-chain article span{color:var(--gold);font-size:.66rem;letter-spacing:.13em}
-.tx-brand-chain article h3{margin:12px 0;color:var(--pale);font-size:1.18rem}
-.tx-brand-chain article p{margin:0;color:var(--soft);line-height:1.7;font-size:.9rem}
-.tx-brand-chain>b{display:grid;place-items:center;color:var(--gold);font-size:1.5rem}
-.tx-integration-map{display:grid;grid-template-columns:minmax(240px,.9fr) auto minmax(220px,.7fr) auto minmax(240px,.9fr);gap:18px;align-items:center;margin-top:34px}
+.tx-cycle-note{max-width:880px;color:var(--muted);font-size:.9rem;line-height:1.8}
+
+/* Architecture and integrations. */
+.tx-brand-chain{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:18px;align-items:stretch;margin-top:38px}
+.tx-brand-chain article{padding:28px;border:1px solid var(--line);border-radius:0;background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96))}
+.tx-brand-chain article span{color:var(--gold);font-size:.62rem;letter-spacing:.13em}
+.tx-brand-chain article h3{margin:13px 0;color:var(--pale);font:600 1rem/1.45 Orbitron,Montserrat,sans-serif}
+.tx-brand-chain article p{margin:0;color:#9da6aa;font-size:.84rem;line-height:1.75}
+.tx-brand-chain>b{display:grid;place-items:center;color:var(--gold);font-size:1.35rem}
+.tx-integration-map{display:grid;grid-template-columns:minmax(240px,.9fr) auto minmax(220px,.7fr) auto minmax(240px,.9fr);gap:18px;align-items:center;margin-top:36px}
 .tx-source-stack,.tx-output-stack{display:grid;gap:8px}
-.tx-source-stack span,.tx-output-stack span{padding:12px 14px;border:1px solid var(--line);border-radius:12px;color:var(--soft);background:rgba(8,11,18,.82);font-size:.8rem}
-.tx-map-arrow{color:var(--gold);font-size:1.8rem;text-align:center}
-.tx-map-core{min-height:230px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid rgba(212,175,55,.42);background:radial-gradient(circle,rgba(212,175,55,.12),rgba(7,10,17,.98) 68%);box-shadow:0 0 70px rgba(212,175,55,.1)}
+.tx-source-stack span,.tx-output-stack span{padding:13px 15px;border:1px solid var(--line);border-radius:0;color:#9da6aa;background:#080b0f;font-size:.76rem;line-height:1.45}
+.tx-map-arrow{color:var(--gold);font-size:1.6rem;text-align:center}
+.tx-map-core{min-height:230px;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;border:1px solid #d8bc7b;background:radial-gradient(circle at 48% 42%,#283038,#0a0e12 68%);box-shadow:inset 0 0 45px rgba(210,174,96,.13),0 0 70px rgba(177,140,70,.10)}
 .tx-map-core img{width:54px;height:54px;margin-bottom:12px}
-.tx-map-core strong{font:600 .8rem Orbitron,Montserrat,sans-serif;color:var(--pale);letter-spacing:.08em}
-.tx-map-core span{color:var(--muted);font-size:.7rem;margin-top:5px}
-.tx-app-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;margin-top:34px}
-.tx-app-grid article{padding:26px;border:1px solid var(--line);border-radius:20px;background:linear-gradient(180deg,rgba(16,21,31,.92),rgba(7,10,17,.94))}
-.tx-app-grid article span{color:var(--gold);font-size:.65rem;letter-spacing:.12em}
-.tx-app-grid h3{margin:12px 0;color:var(--pale);font-size:1.15rem}
-.tx-app-grid p{margin:0;color:var(--soft);line-height:1.72}
-.tx-landscape{background:linear-gradient(180deg,rgba(255,255,255,.012),transparent)}
+.tx-map-core strong{color:var(--pale);font:600 .76rem Orbitron,Montserrat,sans-serif;letter-spacing:.08em}
+.tx-map-core span{margin-top:5px;color:var(--muted);font-size:.66rem}
+
+/* Applications and public research landscape. */
+.tx-app-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px;margin-top:36px}
+.tx-app-grid article{padding:28px;border:1px solid var(--line);border-radius:0;background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96))}
+.tx-app-grid article span{color:var(--gold);font-size:.62rem;letter-spacing:.12em}
+.tx-app-grid h3{margin:13px 0;color:var(--pale);font:600 1rem/1.45 Orbitron,Montserrat,sans-serif}
+.tx-app-grid p{margin:0;color:#9da6aa;font-size:.86rem;line-height:1.78}
 .tx-landscape-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
-.tx-landscape-grid details{border:1px solid var(--line);border-radius:16px;background:rgba(8,11,18,.84)}
-.tx-landscape-grid summary{cursor:pointer;list-style:none;padding:20px;color:var(--pale);font-weight:600}
+.tx-landscape-grid details{border:1px solid var(--line);border-radius:0;background:#080b0f}
+.tx-landscape-grid summary{cursor:pointer;list-style:none;padding:21px;color:var(--pale);font-size:.88rem;font-weight:600}
 .tx-landscape-grid summary::-webkit-details-marker{display:none}
 .tx-landscape-grid summary::after{content:"+";float:right;color:var(--gold)}
 .tx-landscape-grid details[open] summary::after{content:"−"}
-.tx-landscape-grid p{margin:0;padding:0 20px 22px;color:var(--soft);line-height:1.7}
-.tx-landscape-note{margin:20px 0 0;color:var(--muted);font-size:.78rem}
-.tx-cta{padding:86px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
-.tx-cta-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(280px,.45fr);gap:60px;align-items:center}
-.tx-cta h2{margin:16px 0;font-size:clamp(2.5rem,5vw,5.3rem);line-height:1.02;letter-spacing:-.04em}
-.tx-cta p{color:var(--soft);max-width:760px;line-height:1.75}
+.tx-landscape-grid p{margin:0;padding:0 21px 23px;color:#9da6aa;font-size:.84rem;line-height:1.75}
+.tx-landscape-note{margin:22px 0 0;color:var(--muted);font-size:.74rem;line-height:1.7}
+
+/* Final CTA. */
+.tx-cta{padding:100px 0;border-top:1px solid var(--line);border-bottom:1px solid var(--line);background:#040608}
+.tx-cta-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(300px,.42fr);gap:70px;align-items:center}
+.tx-cta h2{margin:16px 0;color:#ece8df;font:500 clamp(2.3rem,4.2vw,4.4rem)/1.05 Orbitron,Montserrat,sans-serif;letter-spacing:-.03em}
+.tx-cta p{max-width:760px;color:#9da6aa;font-size:.9rem;line-height:1.8}
 .tx-cta-actions{display:flex;flex-direction:column;align-items:stretch;gap:12px}
 .tx-cta-actions .btn{width:100%}
-.tx-text-link{text-align:center;color:var(--pale);text-decoration:none;font-size:.85rem;padding:6px}
+.tx-text-link{padding:7px;color:var(--pale);font-size:.78rem;text-align:center;text-decoration:none}
 .tx-text-link:hover{text-decoration:underline}
-.tx-cta-actions small{color:var(--muted);text-align:center;line-height:1.5}
+.tx-cta-actions small{color:var(--muted);font-size:.7rem;line-height:1.55;text-align:center}
+
+/* Dropdown follows the square, restrained OpenProof navigation language. */
+.truthx-nav-menu{border-radius:0!important;background:#070b0c!important}
+
 @keyframes txSpin{to{transform:translate(-50%,-50%) rotate(360deg)}}
 @keyframes txSpinReverse{to{transform:translate(-50%,-50%) rotate(-360deg)}}
-@media(max-width:1040px){
-  .tx-hero-grid,.tx-definition-grid,.tx-heading-row,.tx-cta-grid{grid-template-columns:1fr}
+
+@media(max-width:1050px){
+  .tx-hero-grid{grid-template-columns:1fr;padding-top:72px}
   .tx-hero{min-height:auto}
-  .tx-visual{min-height:470px}
+  .tx-visual{width:min(680px,100%);min-height:620px;margin:-30px auto 0;justify-self:center}
+  .tx-definition-grid,.tx-heading-row,.tx-cta-grid{grid-template-columns:1fr}
   .tx-heading-row{gap:8px}
   .tx-heading-row p{margin-bottom:0}
   .tx-control-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
@@ -117,37 +151,40 @@
   .tx-map-arrow{transform:rotate(90deg)}
   .tx-map-core{width:240px;height:240px;justify-self:center}
 }
+
 @media(max-width:760px){
-  .tx-hero{padding:64px 0 54px}
-  .tx-hero h1{font-size:clamp(2.55rem,13vw,4.4rem)}
-  .tx-visual{min-height:430px}
-  .tx-ring-a{width:330px;height:330px}
-  .tx-ring-b{width:245px;height:245px}
-  .tx-node{font-size:.54rem;padding:8px 10px}
-  .tx-node-2{right:-2%}.tx-node-5{left:-2%}
-  .tx-section{padding:66px 0}
-  .tx-mode-switch{grid-template-columns:1fr;border-radius:18px 18px 0 0}
+  .tx-hero-grid{min-height:auto;padding:65px 22px 80px;display:block}
+  .tx-hero h1{font-size:43px;letter-spacing:-.035em}
+  .tx-hero h1 span{font-size:.52em}
+  .tx-visual{min-height:450px;width:124%;margin:-5px -12% -20px;transform:scale(.83)}
+  .tx-ring-a{width:53%;height:53%}
+  .tx-ring-b{width:76%;height:76%}
+  .tx-section{padding:75px 0}
+  .tx-section>.wrap,.tx-cta>.wrap{width:calc(100% - 44px)}
+  .tx-section h2{font-size:clamp(2rem,11vw,3.25rem)}
+  .tx-mode-switch{grid-template-columns:1fr}
   .tx-mode-switch button{border-right:0;border-bottom:1px solid var(--line)}
   .tx-mode-switch button:last-child{border-bottom:0}
-  .tx-mode-panel{grid-template-columns:1fr;padding:26px}
+  .tx-mode-panel{grid-template-columns:1fr;padding:28px}
   .tx-control-grid,.tx-app-grid,.tx-landscape-grid{grid-template-columns:1fr}
   .tx-brand-chain{grid-template-columns:1fr}
-  .tx-brand-chain>b{transform:rotate(90deg);min-height:22px}
+  .tx-brand-chain>b{min-height:22px;transform:rotate(90deg)}
   .tx-cycle-line{gap:7px}
-  .tx-cycle-line span{font-size:.7rem;padding:8px 10px}
-  .tx-cta h2{font-size:clamp(2.35rem,12vw,4.2rem)}
+  .tx-cycle-line span{padding:8px 10px;font-size:.68rem}
+  .tx-cta{padding:75px 0}
+  .tx-cta h2{font-size:clamp(2.2rem,11vw,3.6rem)}
 }
+
 @media(max-width:500px){
-  .tx-visual{min-height:390px}
-  .tx-ring-a{width:285px;height:285px}
-  .tx-ring-b{width:210px;height:210px}
-  .tx-core{width:126px;height:126px}
-  .tx-node-1{top:3%}
-  .tx-node-3{bottom:8%;right:0}
-  .tx-node-4{bottom:4%;left:0}
+  .tx-visual{min-height:410px}
+  .tx-core{width:136px;height:136px}
+  .tx-node-1{top:10%}
+  .tx-node-3{right:0;bottom:13%}
+  .tx-node-4{left:0;bottom:10%}
   .tx-crossline{gap:6px}
-  .tx-crossline span{font-size:.56rem}
+  .tx-crossline span{font-size:.54rem}
 }
+
 @media(prefers-reduced-motion:reduce){
   .tx-ring-a,.tx-ring-b{animation:none!important}
 }


### PR DESCRIPTION
## Correction requested after visual review

The doctrine and content remain unchanged. This PR corrects only the visual system of the public TruthX Engine page so that it follows the RPO homepage and `/tests` rather than the more cinematic Founder-page language.

## What changes

- restores the canonical edge-to-edge hero geometry used by the RPO homepage and verification page
- aligns the headline scale, uppercase treatment, margins and button rhythm
- replaces the previous rounded/pill-heavy components with the square, restrained OpenProof panel system
- replaces older bright-gold and blue accents with the current warm-metal / steel palette
- restyles the TruthX integrity object to echo the public RPO object and its minimal signal labels
- introduces the same alternating dark section fields used across the technical pages
- justifies substantive editorial text in French and English while keeping navigation, labels and buttons naturally aligned
- preserves responsive behaviour, reduced-motion support, all doctrine, all CTAs and all interactions

## Scope

Only `docs/assets/truthx-engine.css` changes. No copy, route, metadata, JavaScript, CTA or product logic is modified.