### PR TITLE
Reframe the Founder profile around the TruthX doctrine

### DIFF
--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -90,7 +90,8 @@
 .founder-contact{background:#050709}
 
 /* Shared restrained panels. */
-.founder-signal-grid,.founder-integrity-grid,.founder-now-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-block:1px solid var(--founder-line)}
+.founder-signal-grid,.founder-now-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-block:1px solid var(--founder-line)}
+.founder-integrity-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));border-block:1px solid var(--founder-line)}
 .founder-signal-card,.founder-integrity-card,.founder-now-card{position:relative;min-height:290px;padding:31px 27px 29px;overflow:hidden;border-right:1px solid var(--founder-line);background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96))}
 .founder-signal-card:last-child,.founder-integrity-card:last-child,.founder-now-card:last-child{border-right:0}
 .founder-signal-card::before,.founder-integrity-card::before,.founder-now-card::before,.founder-proof-card::before{position:absolute;inset:0;opacity:0;pointer-events:none;background:radial-gradient(330px circle at var(--pointer-x,50%) var(--pointer-y,50%),rgba(196,154,88,.11),transparent 62%);content:"";transition:opacity .25s ease}
@@ -199,10 +200,10 @@ html.motion-ready .founder-page [data-reveal].is-visible,html.motion-ready .foun
 /* Responsive */
 @media(max-width:1120px){
   .founder-hero-inner{grid-template-columns:1fr minmax(360px,.62fr)}
-  .founder-signal-grid,.founder-integrity-grid,.founder-now-grid,.founder-proof-grid{grid-template-columns:repeat(2,1fr)}
-  .founder-signal-card:nth-child(2),.founder-integrity-card:nth-child(2),.founder-now-card:nth-child(2),.founder-proof-card:nth-child(2){border-right:0}
-  .founder-signal-card,.founder-integrity-card,.founder-now-card,.founder-proof-card{border-bottom:1px solid var(--founder-line)}
-  .founder-signal-card:nth-last-child(-n+2),.founder-integrity-card:nth-last-child(-n+2),.founder-now-card:nth-last-child(-n+2),.founder-proof-card:nth-last-child(-n+2){border-bottom:0}
+  .founder-signal-grid,.founder-now-grid,.founder-proof-grid{grid-template-columns:repeat(2,1fr)}
+  .founder-signal-card:nth-child(2),.founder-now-card:nth-child(2),.founder-proof-card:nth-child(2){border-right:0}
+  .founder-signal-card,.founder-now-card,.founder-proof-card{border-bottom:1px solid var(--founder-line)}
+  .founder-signal-card:nth-last-child(-n+2),.founder-now-card:nth-last-child(-n+2),.founder-proof-card:nth-last-child(-n+2){border-bottom:0}
   .founder-chain{grid-template-columns:1fr 30px 1fr}
   .founder-chain article:nth-of-type(3){grid-column:1}
   .founder-chain article:nth-of-type(4){grid-column:3}
@@ -216,6 +217,9 @@ html.motion-ready .founder-page [data-reveal].is-visible,html.motion-ready .foun
   .founder-credibility span:nth-child(-n+2){border-bottom:1px solid var(--founder-line)}
   .founder-heading-grid,.founder-method-grid,.founder-origin-grid,.founder-contact-grid{grid-template-columns:1fr;gap:34px}
   .founder-heading-grid{margin-bottom:36px}
+  .founder-integrity-grid{grid-template-columns:1fr}
+  .founder-integrity-card{min-height:auto;border-right:0;border-bottom:1px solid var(--founder-line)}
+  .founder-integrity-card:last-child{border-bottom:0}
   .founder-modes-grid{grid-template-columns:1fr}
   .founder-mode-card{border-right:0;border-bottom:1px solid var(--founder-line)}
   .founder-mode-card:last-child{border-bottom:0}

--- a/docs/assets/founder-reputation.css
+++ b/docs/assets/founder-reputation.css
@@ -1,1493 +1,267 @@
 /*
- * Gersende de Parcey — cinematic reputation page
- * Loaded only by the two founder pages. All selectors remain page-scoped.
+ * Gersende de Parcey — institutional Founder profile
+ * Canonical OpenProof / RPO charter with a controlled human layer.
+ * Loaded only by the two Founder pages.
  */
 
-.founder-page {
-  --founder-ivory: #e9e4d9;
-  --founder-ivory-deep: #d8d0c2;
-  --founder-night: #050709;
-  --founder-slate: #0d1217;
-  --founder-slate-soft: #111820;
-  --founder-gold: #c49a58;
-  --founder-gold-light: #e1c38a;
-  --founder-text: #f1ede4;
-  --founder-soft: #9da6aa;
-  --founder-line: rgba(214, 194, 139, .17);
-  overflow-x: clip;
-  background: var(--founder-night);
-  color: var(--founder-text);
-  font-family: Montserrat, "Helvetica Neue", Arial, sans-serif;
+.founder-page{
+  --founder-ivory:#f1ede4;
+  --founder-soft:#9da6aa;
+  --founder-muted:#70797d;
+  --founder-gold:#c49a58;
+  --founder-pale:#e1c38a;
+  --founder-line:rgba(214,194,139,.17);
+  overflow-x:clip;
+  background:#050709;
+  color:var(--founder-ivory);
+  font-family:Montserrat,"Helvetica Neue",Arial,sans-serif;
 }
-
-.founder-page main {
-  position: relative;
-  isolation: isolate;
-}
-
+.founder-page main{position:relative;isolation:isolate}
+.founder-page main h1,
 .founder-page main h2,
-.founder-page main h3 {
-  font-family: Montserrat, "Helvetica Neue", Arial, sans-serif;
-}
-
+.founder-page main h3,
 .founder-page .founder-kicker,
-.founder-page .founder-meta,
 .founder-page .founder-number,
 .founder-page .founder-proof-status,
-.founder-page .founder-rail,
-.founder-page .founder-system-role {
-  font-family: Orbitron, Montserrat, sans-serif;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-kicker {
-  margin: 0 0 22px;
-  color: var(--founder-gold);
-  font-size: 8px;
-  font-weight: 600;
-  line-height: 1.45;
-  letter-spacing: 2.25px;
-}
-
-.founder-page .founder-section-title {
-  max-width: 940px;
-  margin: 0;
-  color: var(--founder-text);
-  font-size: clamp(38px, 4.45vw, 66px);
-  font-weight: 500;
-  line-height: 1.08;
-  letter-spacing: -.037em;
-}
-
-.founder-page .founder-section-lead {
-  max-width: 760px;
-  margin: 28px 0 0;
-  color: var(--founder-soft);
-  font-size: clamp(15px, 1.25vw, 18px);
-  line-height: 1.82;
-}
-
-.founder-page .founder-section-lead strong {
-  color: var(--founder-text);
-  font-weight: 500;
-}
-
-.founder-page .founder-chapter {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  padding: 122px 0;
-  border-bottom: 1px solid var(--founder-line);
-}
-
-.founder-page .founder-chapter::before {
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  content: "";
-}
-
-/* Hero */
-.founder-page .founder-hero {
-  position: relative;
-  min-height: calc(100svh - 92px);
-  overflow: hidden;
-  border-bottom: 1px solid var(--founder-line);
-  background:
-    radial-gradient(700px 620px at 82% 43%, rgba(196, 154, 88, .12), rgba(43, 53, 64, .08) 37%, transparent 72%),
-    linear-gradient(180deg, #050709, #030507);
-}
-
-.founder-page .founder-hero::before {
-  background:
-    radial-gradient(ellipse 69% 45% at 93% 49%, transparent 0 66%, rgba(197, 176, 125, .15) 66.2% 66.35%, transparent 66.55%),
-    radial-gradient(ellipse 83% 55% at 93% 49%, transparent 0 69%, rgba(197, 176, 125, .10) 69.2% 69.32%, transparent 69.52%),
-    radial-gradient(ellipse 98% 66% at 93% 49%, transparent 0 71%, rgba(197, 176, 125, .07) 71.2% 71.3%, transparent 71.5%);
-}
-
-.founder-page .founder-hero::after {
-  position: absolute;
-  top: 8%;
-  right: 2%;
-  width: min(49vw, 720px);
-  height: auto;
-  aspect-ratio: 1;
-  z-index: -1;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(218, 182, 113, .10), rgba(67, 78, 89, .08) 33%, transparent 68%);
-  filter: blur(5px);
-  content: "";
-  animation: founderHalo 15s ease-in-out infinite alternate;
-}
-
-.founder-page .founder-hero-inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(390px, .72fr);
-  column-gap: clamp(42px, 5vw, 84px);
-  row-gap: 24px;
-  align-items: center;
-  min-height: calc(100svh - 92px);
-  padding: 70px 0 54px;
-}
-
-.founder-page .founder-hero-copy {
-  position: relative;
-  z-index: 2;
-}
-
-.founder-page .founder-hero h1 {
-  max-width: 870px;
-  margin: 0;
-  color: var(--founder-text);
-  font: 500 clamp(52px, 5.35vw, 82px)/.99 Orbitron, Montserrat, sans-serif;
-  letter-spacing: -.047em;
-  text-shadow: 0 8px 40px rgba(0, 0, 0, .42);
-}
-
-.founder-page .founder-hero h1 span {
-  display: block;
-  margin-top: 8px;
-  color: var(--founder-gold);
-}
-
-.founder-page .founder-hero-lead {
-  max-width: 720px;
-  margin: 32px 0 0;
-  color: var(--founder-soft);
-  font-size: clamp(15px, 1.25vw, 18px);
-  line-height: 1.85;
-}
-
-.founder-page .founder-actions {
-  display: flex;
-  gap: 14px 22px;
-  align-items: center;
-  flex-wrap: wrap;
-  margin-top: 38px;
-}
-
-.founder-page .founder-actions .btn {
-  min-height: 51px;
-  padding: 15px 20px;
-  border: 1px solid #596064;
-  background: transparent;
-  color: #c8cccc;
-  font: 700 8px/1.3 Montserrat, sans-serif;
-  letter-spacing: 1.3px;
-  text-transform: uppercase;
-  transition: color .25s ease, border-color .25s ease, background .25s ease, transform .25s ease;
-}
-
-.founder-page .founder-actions .btn:hover,
-.founder-page .founder-actions .btn:focus-visible {
-  border-color: var(--founder-gold-light);
-  color: var(--founder-gold-light);
-  transform: translateY(-2px);
-}
-
-.founder-page .founder-actions .btn.primary {
-  border-color: #d0b06b;
-  background: linear-gradient(110deg, #ad8747, #dfc17e);
-  color: #090b0d;
-  box-shadow: 0 16px 42px rgba(173, 135, 71, .18);
-}
-
-.founder-page .founder-actions .btn.primary:hover,
-.founder-page .founder-actions .btn.primary:focus-visible {
-  border-color: #ecd292;
-  background: linear-gradient(110deg, #c49d59, #eed397);
-  color: #090b0d;
-}
-
-.founder-page .founder-text-link {
-  display: inline-flex;
-  align-items: center;
-  min-height: 44px;
-  padding: 10px 0 8px;
-  border-bottom: 1px solid rgba(225, 195, 138, .48);
-  color: var(--founder-text);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 1.25px;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: color .25s ease, border-color .25s ease;
-}
-
-.founder-page .founder-text-link:hover,
-.founder-page .founder-text-link:focus-visible {
-  border-color: var(--founder-gold-light);
-  color: var(--founder-gold-light);
-}
-
-.founder-page .founder-portrait-stage {
-  position: relative;
-  width: min(100%, 460px);
-  margin: 0 0 0 auto;
-  perspective: 1200px;
-}
-
-.founder-page .founder-portrait-stage::before,
-.founder-page .founder-portrait-stage::after {
-  position: absolute;
-  z-index: -1;
-  border: 1px solid rgba(225, 195, 138, .24);
-  content: "";
-  pointer-events: none;
-}
-
-.founder-page .founder-portrait-stage::before {
-  inset: -22px 25px 34px -24px;
-}
-
-.founder-page .founder-portrait-stage::after {
-  inset: 36px -28px -20px 31px;
-  border-color: rgba(157, 166, 170, .16);
-}
-
-.founder-page .founder-portrait-card {
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: .79;
-  border: 1px solid rgba(225, 195, 138, .40);
-  background: var(--founder-ivory);
-  box-shadow:
-    0 42px 110px rgba(0, 0, 0, .55),
-    0 0 70px rgba(196, 154, 88, .10);
-  transform-style: preserve-3d;
-  transition: transform .35s ease-out, box-shadow .35s ease-out;
-}
-
-.founder-page .founder-portrait-card::before {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  border: 12px solid rgba(5, 7, 9, .035);
-  box-shadow: inset 0 0 0 1px rgba(6, 9, 12, .10);
-  content: "";
-  pointer-events: none;
-}
-
-.founder-page .founder-portrait-card::after {
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  background:
-    linear-gradient(180deg, transparent 52%, rgba(4, 7, 9, .10) 77%, rgba(4, 7, 9, .82) 100%),
-    linear-gradient(112deg, transparent 32%, rgba(255, 255, 255, .18) 48%, transparent 62%);
-  background-size: 100% 100%, 220% 100%;
-  content: "";
-  pointer-events: none;
-  animation: founderPortraitLight 11s ease-in-out infinite alternate;
-}
-
-.founder-page .founder-portrait-card img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center 24%;
-  filter: saturate(.74) contrast(1.05);
-}
-
-.founder-page .founder-portrait-label {
-  position: absolute;
-  right: 24px;
-  bottom: 22px;
-  left: 24px;
-  z-index: 3;
-  display: flex;
-  justify-content: space-between;
-  gap: 22px;
-  align-items: flex-end;
-  color: var(--founder-text);
-}
-
-.founder-page .founder-portrait-label strong {
-  display: block;
-  font: 600 13px/1.3 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1.15px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-portrait-label > span {
-  display: block;
-}
-
-.founder-page .founder-portrait-label > span > span {
-  display: block;
-  margin-top: 6px;
-  color: #b8bcba;
-  font-size: 8px;
-  line-height: 1.55;
-  letter-spacing: 1.1px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-portrait-mark {
-  color: var(--founder-gold-light);
-  font: 500 36px/1 Orbitron, sans-serif;
-}
-
-.founder-page .founder-portrait-stat {
-  position: absolute;
-  z-index: 4;
-  min-width: 145px;
-  padding: 15px 17px;
-  border: 1px solid rgba(214, 194, 139, .25);
-  background: rgba(7, 10, 13, .88);
-  box-shadow: 0 18px 45px rgba(0, 0, 0, .33);
-  backdrop-filter: blur(9px);
-}
-
-.founder-page .founder-portrait-stat span {
-  display: block;
-  color: #81898c;
-  font: 600 7px/1.4 Orbitron, sans-serif;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-portrait-stat strong {
-  display: block;
-  margin-top: 7px;
-  color: var(--founder-gold-light);
-  font: 500 14px/1.3 Montserrat, sans-serif;
-}
-
-.founder-page .founder-portrait-stat--top {
-  top: 9%;
-  right: -35px;
-}
-
-.founder-page .founder-portrait-stat--bottom {
-  bottom: 18%;
-  left: -42px;
-}
-
-.founder-page .founder-credibility {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-column: 1 / -1;
-  margin-top: 0;
-  border-top: 1px solid var(--founder-line);
-  border-bottom: 1px solid var(--founder-line);
-}
-
-.founder-page .founder-credibility span {
-  padding: 18px 19px;
-  border-right: 1px solid var(--founder-line);
-  color: #858e91;
-  font: 600 7px/1.5 Orbitron, sans-serif;
-  letter-spacing: 1.25px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-credibility span:last-child {
-  border-right: 0;
-}
-
-/* Moving proof rail */
-.founder-page .founder-rail {
-  overflow: hidden;
-  border-bottom: 1px solid var(--founder-line);
-  background: #080b0e;
-  color: #8a9294;
-  font-size: 7px;
-  line-height: 1;
-  letter-spacing: 1.7px;
-}
-
-.founder-page .founder-rail-track {
-  display: flex;
-  width: max-content;
-  padding: 19px 0;
-  animation: founderRail 34s linear infinite;
-}
-
-.founder-page .founder-rail-group {
-  display: flex;
-  flex-shrink: 0;
-  gap: 30px;
-  align-items: center;
-  padding-right: 30px;
-}
-
-.founder-page .founder-rail-group i {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--founder-gold);
-  box-shadow: 0 0 10px rgba(196, 154, 88, .5);
-}
-
-/* Professional field */
-.founder-page .founder-field::before {
-  background:
-    radial-gradient(600px 470px at 10% 42%, rgba(196, 154, 88, .07), transparent 72%),
-    linear-gradient(180deg, #06090c, #080c10);
-}
-
-.founder-page .founder-intro-grid {
-  display: grid;
-  grid-template-columns: minmax(250px, .35fr) minmax(0, .65fr);
-  gap: clamp(46px, 7vw, 110px);
-  align-items: start;
-}
-
-.founder-page .founder-field .founder-section-lead {
-  margin-top: 4px;
-}
-
-.founder-page .founder-card-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-  margin-top: 68px;
-}
-
-.founder-page .founder-card {
-  --pointer-x: 50%;
-  --pointer-y: 50%;
-  position: relative;
-  display: flex;
-  min-height: 310px;
-  overflow: hidden;
-  flex-direction: column;
-  padding: 30px;
-  border: 1px solid var(--founder-line);
-  background: linear-gradient(155deg, rgba(17, 24, 31, .94), rgba(6, 9, 12, .98));
-  box-shadow: 0 24px 55px rgba(0, 0, 0, .18);
-  transition: transform .3s ease, border-color .3s ease, box-shadow .3s ease;
-}
-
-.founder-page .founder-card::before {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  background: radial-gradient(360px circle at var(--pointer-x) var(--pointer-y), rgba(225, 195, 138, .12), transparent 57%);
-  content: "";
-  pointer-events: none;
-  transition: opacity .3s ease;
-}
-
-.founder-page .founder-card:hover,
-.founder-page .founder-card:focus-within {
-  border-color: rgba(225, 195, 138, .42);
-  box-shadow: 0 34px 75px rgba(0, 0, 0, .34), 0 0 45px rgba(196, 154, 88, .05);
-  transform: translateY(-6px);
-}
-
-.founder-page .founder-card:hover::before,
-.founder-page .founder-card:focus-within::before {
-  opacity: 1;
-}
-
-.founder-page .founder-number {
-  position: relative;
-  z-index: 1;
-  color: var(--founder-gold);
-  font-size: 9px;
-  letter-spacing: 1.2px;
-}
-
-.founder-page .founder-card h3 {
-  position: relative;
-  z-index: 1;
-  max-width: 300px;
-  margin: auto 0 18px;
-  color: var(--founder-text);
-  font-size: clamp(21px, 1.8vw, 28px);
-  font-weight: 500;
-  line-height: 1.25;
-  letter-spacing: -.025em;
-}
-
-.founder-page .founder-card p {
-  position: relative;
-  z-index: 1;
-  margin: 0;
-  color: var(--founder-soft);
-  font-size: 14px;
-  line-height: 1.75;
-}
-
-/* Origin: bright editorial break */
-.founder-page .founder-origin {
-  border-color: rgba(15, 21, 27, .13);
-  background: var(--founder-ivory);
-  color: #10151a;
-}
-
-.founder-page .founder-origin::before {
-  background:
-    linear-gradient(90deg, transparent 0 63%, rgba(16, 21, 26, .035) 63% 63.1%, transparent 63.1%),
-    radial-gradient(600px 450px at 82% 26%, rgba(196, 154, 88, .10), transparent 72%);
-}
-
-.founder-page .founder-origin .founder-kicker {
-  color: #76592e;
-}
-
-.founder-page .founder-origin .founder-section-title {
-  color: #11171d;
-}
-
-.founder-page .founder-origin-head {
-  display: grid;
-  grid-template-columns: minmax(0, .72fr) minmax(330px, .28fr);
-  gap: 70px;
-  align-items: end;
-}
-
-.founder-page .founder-origin-thesis {
-  margin: 0 0 6px;
-  padding-left: 23px;
-  border-left: 2px solid #9b7741;
-  color: #4e555a;
-  font-size: 15px;
-  line-height: 1.82;
-}
-
-.founder-page .founder-origin-map {
-  display: grid;
-  grid-template-columns: 1fr 110px 1fr;
-  gap: 0;
-  align-items: stretch;
-  margin-top: 72px;
-  border-top: 1px solid rgba(15, 21, 27, .16);
-  border-bottom: 1px solid rgba(15, 21, 27, .16);
-}
-
-.founder-page .founder-origin-event {
-  min-height: 330px;
-  padding: 32px 34px;
-}
-
-.founder-page .founder-origin-event:first-child {
-  border-right: 1px solid rgba(15, 21, 27, .16);
-}
-
-.founder-page .founder-origin-event:last-child {
-  border-left: 1px solid rgba(15, 21, 27, .16);
-}
-
-.founder-page .founder-origin-event .founder-number {
-  color: #76592e;
-}
-
-.founder-page .founder-origin-event h3 {
-  margin: 58px 0 20px;
-  color: #151a1e;
-  font-size: clamp(24px, 2.2vw, 33px);
-  font-weight: 500;
-  line-height: 1.18;
-  letter-spacing: -.03em;
-}
-
-.founder-page .founder-origin-event p {
-  max-width: 470px;
-  margin: 0;
-  color: #53595d;
-  font-size: 14px;
-  line-height: 1.8;
-}
-
-.founder-page .founder-origin-bridge {
-  position: relative;
-  display: grid;
-  place-items: center;
-}
-
-.founder-page .founder-origin-bridge::before {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 1px;
-  background: rgba(138, 108, 61, .28);
-  content: "";
-}
-
-.founder-page .founder-origin-bridge span {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  width: 88px;
-  height: 88px;
-  place-items: center;
-  border: 1px solid rgba(138, 108, 61, .42);
-  border-radius: 50%;
-  background: var(--founder-ivory);
-  color: #7d6239;
-  font: 600 7px/1.55 Orbitron, sans-serif;
-  letter-spacing: 1.1px;
-  text-align: center;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-origin-conclusion {
-  max-width: 980px;
-  margin: 52px 0 0;
-  color: #151a1e;
-  font-size: clamp(23px, 2.45vw, 36px);
-  font-weight: 500;
-  line-height: 1.42;
-  letter-spacing: -.025em;
-}
-
-.founder-page .founder-origin-conclusion strong {
-  color: #8a6937;
-  font-weight: 500;
-}
+.founder-page .founder-axis-city,
+.founder-page .founder-form-kicker{font-family:Orbitron,Montserrat,sans-serif}
+.founder-wrap{width:min(1240px,calc(100% - 12vw));margin:auto}
+.founder-kicker{margin:0;color:var(--founder-gold);font-size:7px;font-weight:700;line-height:1.45;letter-spacing:2.2px;text-transform:uppercase}
+.founder-section-title{max-width:980px;margin:16px 0 0;color:#ece8df;font:500 clamp(2.15rem,3.75vw,4.05rem)/1.08 Orbitron,Montserrat,sans-serif;letter-spacing:-.028em;text-transform:uppercase}
+.founder-heading-grid{display:grid;grid-template-columns:minmax(0,1fr) minmax(330px,.43fr);gap:72px;align-items:end;margin-bottom:45px}
+.founder-section-lead,.founder-method-intro,.founder-contact-copy{margin:0 0 9px;color:var(--founder-soft);font-size:.95rem;line-height:1.9}
+@media(min-width:821px){
+  .founder-page .editorial,
+  .founder-page .founder-hero-lead,
+  .founder-page .founder-signal-card p,
+  .founder-page .founder-integrity-card p,
+  .founder-page .founder-mode-card p,
+  .founder-page .founder-mode-card li,
+  .founder-page .founder-origin-copy>p,
+  .founder-page .founder-origin-points p,
+  .founder-page .founder-chain article p,
+  .founder-page .founder-axis-grid article>p,
+  .founder-page .founder-axis-grid li,
+  .founder-page .founder-proof-card p,
+  .founder-page .founder-now-card p,
+  .founder-page .founder-contact-intro{text-align:justify;text-align-last:left;text-justify:inter-word;hyphens:auto;-webkit-hyphens:auto}
+}
+
+/* Hero — same edge-to-edge geometry as the RPO homepage and /tests. */
+.founder-hero{position:relative;min-height:790px;padding:0;overflow:hidden;border-bottom:1px solid var(--founder-line);background:#050709}
+.founder-hero::before{background:radial-gradient(ellipse 78% 48% at 100% 46%,transparent 0 66.5%,rgba(197,176,125,.15) 66.7% 66.85%,transparent 67.05%),radial-gradient(ellipse 91% 57% at 100% 46%,transparent 0 69%,rgba(197,176,125,.11) 69.2% 69.32%,transparent 69.5%),radial-gradient(ellipse 106% 67% at 100% 46%,transparent 0 71%,rgba(197,176,125,.08) 71.2% 71.3%,transparent 71.5%);background-size:auto;mask-image:none}
+.founder-hero::after{width:720px;height:720px;right:-90px;top:40px;background:radial-gradient(circle,rgba(175,133,72,.09),rgba(43,53,64,.14) 25%,transparent 67%);filter:blur(6px)}
+.founder-hero-inner{width:100%;min-height:790px;margin:0;padding:92px 6vw 72px;display:grid;grid-template-columns:minmax(550px,1fr) minmax(430px,.72fr);column-gap:5vw;row-gap:40px;align-items:center}
+.founder-hero-copy{position:relative;z-index:2}
+.founder-hero h1{max-width:860px;margin:23px 0 31px;color:#ece8df;font:500 clamp(51px,5.2vw,78px)/.98 Orbitron,Montserrat,sans-serif;letter-spacing:-.035em;text-transform:uppercase;text-shadow:0 4px 35px #000}
+.founder-hero h1 span{display:block;margin-top:18px;color:var(--founder-gold);font-size:.48em;line-height:1.16;letter-spacing:-.02em}
+.founder-hero-lead{max-width:670px;margin:0;color:#9ca4a5;font-size:14px;line-height:1.9;letter-spacing:.15px}
+.founder-crossline{display:flex;align-items:center;flex-wrap:wrap;gap:8px;margin:31px 0 0;color:#70797d;font:600 7px/1.4 Orbitron,Montserrat,sans-serif;letter-spacing:1.25px}
+.founder-crossline b{color:var(--founder-gold);font-size:1rem;font-weight:500}
+.founder-actions{display:flex;gap:14px 28px;align-items:center;flex-wrap:wrap;margin-top:38px}
+.founder-actions .btn{min-height:48px;padding:15px 21px;border-radius:0;color:#aeb4b4;background:transparent;border:1px solid #596064;font:700 8px/1.2 Montserrat,sans-serif;letter-spacing:1.35px;text-transform:uppercase}
+.founder-actions .btn:hover,.founder-actions .btn:focus-visible{border-color:#dec083;color:#dec083}
+.founder-actions .btn.primary{background:linear-gradient(110deg,#ad8747,#dfc17e);border-color:#d0b06b;color:#0a0c0e}
+.founder-actions .btn.primary:hover,.founder-actions .btn.primary:focus-visible{background:linear-gradient(110deg,#c49d59,#eed397);color:#0a0c0e}
+.founder-text-link{display:inline-flex;align-items:center;min-height:42px;padding:9px 0 7px;border-bottom:1px solid rgba(225,195,138,.48);color:#d0d3d1;font-size:8px;font-weight:700;letter-spacing:1.2px;text-decoration:none;text-transform:uppercase}
+.founder-text-link:hover,.founder-text-link:focus-visible{border-color:var(--founder-pale);color:var(--founder-pale)}
+
+/* Portrait — human, but no parallel cinematic brand. */
+.founder-portrait-stage{position:relative;width:min(100%,430px);margin:0 0 0 auto;perspective:1200px}
+.founder-portrait-frame{position:relative;padding:13px;border:1px solid rgba(214,194,139,.28);background:rgba(9,13,18,.72);box-shadow:0 38px 105px rgba(0,0,0,.5),0 0 65px rgba(196,154,88,.08)}
+.founder-portrait-frame::before,.founder-portrait-frame::after{position:absolute;content:"";pointer-events:none}
+.founder-portrait-frame::before{inset:-20px 34px 38px -24px;z-index:-1;border:1px solid rgba(225,195,138,.16)}
+.founder-portrait-frame::after{inset:38px -24px -18px 30px;z-index:-1;border:1px solid rgba(133,150,156,.12)}
+.founder-portrait-card{position:relative;overflow:hidden;aspect-ratio:.79;border:1px solid rgba(225,195,138,.20);background:#d9d1c3;transform-style:preserve-3d;transition:transform .35s ease-out,box-shadow .35s ease-out}
+.founder-portrait-card::after{position:absolute;inset:0;z-index:2;background:linear-gradient(180deg,transparent 57%,rgba(4,7,9,.10) 76%,rgba(4,7,9,.88) 100%);content:"";pointer-events:none}
+.founder-portrait-card img{display:block;width:100%;height:100%;object-fit:cover;object-position:center 24%;filter:saturate(.72) contrast(1.04)}
+.founder-portrait-label{position:absolute;right:31px;bottom:29px;left:31px;z-index:4;display:flex;align-items:flex-end;justify-content:space-between;gap:20px;color:var(--founder-ivory)}
+.founder-portrait-label strong{display:block;font:600 12px/1.3 Orbitron,Montserrat,sans-serif;letter-spacing:1.05px;text-transform:uppercase}
+.founder-portrait-label>span>span{display:block;margin-top:6px;color:#b7bcba;font-size:7px;line-height:1.55;letter-spacing:1.05px;text-transform:uppercase}
+.founder-portrait-label>b{color:var(--founder-pale);font:500 34px/1 Orbitron,sans-serif}
+.founder-credibility{display:grid;grid-template-columns:repeat(4,1fr);grid-column:1/-1;border-top:1px solid var(--founder-line);border-bottom:1px solid var(--founder-line)}
+.founder-credibility span{padding:18px 19px;border-right:1px solid var(--founder-line);color:#858e91;font:600 7px/1.5 Orbitron,sans-serif;letter-spacing:1.25px;text-transform:uppercase}
+.founder-credibility span:last-child{border-right:0}
+
+/* Chapters */
+.founder-chapter{position:relative;overflow:hidden;padding:105px 0;border-bottom:1px solid var(--founder-line)}
+.founder-sight,.founder-origin,.founder-verification{background:#080b0f}
+.founder-built,.founder-modes,.founder-method,.founder-architecture,.founder-axis,.founder-now{background:#0d1217}
+.founder-contact{background:#050709}
+
+/* Shared restrained panels. */
+.founder-signal-grid,.founder-integrity-grid,.founder-now-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-block:1px solid var(--founder-line)}
+.founder-signal-card,.founder-integrity-card,.founder-now-card{position:relative;min-height:290px;padding:31px 27px 29px;overflow:hidden;border-right:1px solid var(--founder-line);background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96))}
+.founder-signal-card:last-child,.founder-integrity-card:last-child,.founder-now-card:last-child{border-right:0}
+.founder-signal-card::before,.founder-integrity-card::before,.founder-now-card::before,.founder-proof-card::before{position:absolute;inset:0;opacity:0;pointer-events:none;background:radial-gradient(330px circle at var(--pointer-x,50%) var(--pointer-y,50%),rgba(196,154,88,.11),transparent 62%);content:"";transition:opacity .25s ease}
+.founder-signal-card:hover::before,.founder-integrity-card:hover::before,.founder-now-card:hover::before,.founder-proof-card:hover::before{opacity:1}
+.founder-number{position:relative;z-index:1;color:var(--founder-gold);font-size:.61rem;letter-spacing:.13em}
+.founder-signal-card h3,.founder-integrity-card h3,.founder-now-card h3{position:relative;z-index:1;margin:31px 0 17px;color:var(--founder-pale);font:600 .96rem/1.45 Orbitron,Montserrat,sans-serif;letter-spacing:.02em}
+.founder-signal-card p,.founder-integrity-card p,.founder-now-card p{position:relative;z-index:1;margin:0;color:var(--founder-soft);font-size:.88rem;line-height:1.8}
+.founder-doctrine{margin:38px 0 0;padding:26px 29px;border-left:2px solid var(--founder-gold);background:rgba(196,154,88,.055);color:#ddd7ca;font:500 clamp(1.02rem,1.7vw,1.32rem)/1.7 Montserrat,sans-serif}
+
+/* Two modes */
+.founder-modes-grid{display:grid;grid-template-columns:1fr 1fr;border:1px solid var(--founder-line)}
+.founder-mode-card{padding:37px 39px 39px;border-right:1px solid var(--founder-line);background:#080b0f}
+.founder-mode-card:last-child{border-right:0}
+.founder-mode-card h3{margin:28px 0 17px;color:var(--founder-pale);font-size:1.15rem;line-height:1.45}
+.founder-mode-card p,.founder-mode-card li{color:var(--founder-soft);font-size:.91rem;line-height:1.82}
+.founder-mode-card ul{margin:25px 0 0;padding:22px 0 0 20px;border-top:1px solid rgba(255,255,255,.07)}
+.founder-mode-card li{margin:0 0 9px;padding-left:4px}
 
 /* Method */
-.founder-page .founder-method::before {
-  background:
-    radial-gradient(700px 520px at 77% 38%, rgba(61, 75, 88, .16), transparent 70%),
-    linear-gradient(180deg, #05080b, #070b0f);
-}
-
-.founder-page .founder-method-grid {
-  display: grid;
-  grid-template-columns: minmax(270px, .38fr) minmax(0, .62fr);
-  gap: clamp(50px, 8vw, 120px);
-  align-items: start;
-}
-
-.founder-page .founder-method-copy {
-  max-width: 720px;
-}
-
-.founder-page .founder-method-copy p {
-  margin: 0 0 24px;
-  color: var(--founder-soft);
-  font-size: 15px;
-  line-height: 1.85;
-}
-
-.founder-page .founder-method-copy strong {
-  color: var(--founder-gold-light);
-  font-weight: 500;
-}
-
-.founder-page .founder-questions {
-  margin-top: 40px;
-  border-top: 1px solid var(--founder-line);
-}
-
-.founder-page .founder-question {
-  display: grid;
-  grid-template-columns: 48px 1fr;
-  gap: 16px;
-  align-items: center;
-  min-height: 66px;
-  border-bottom: 1px solid var(--founder-line);
-  color: #c5c9c7;
-  font-size: 14px;
-}
-
-.founder-page .founder-question b {
-  color: var(--founder-gold);
-  font: 600 8px/1 Orbitron, sans-serif;
-  letter-spacing: 1px;
-}
-
-.founder-page .founder-question span {
-  transition: color .2s ease, transform .2s ease;
-}
-
-.founder-page .founder-question:hover span {
-  color: var(--founder-text);
-  transform: translateX(4px);
-}
-
-/* Shift + product architecture */
-.founder-page .founder-shift {
-  background: var(--founder-slate);
-}
-
-.founder-page .founder-shift::before {
-  background:
-    linear-gradient(rgba(255, 255, 255, .012) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, .012) 1px, transparent 1px),
-    radial-gradient(650px 520px at 22% 46%, rgba(196, 154, 88, .08), transparent 70%);
-  background-size: 70px 70px, 70px 70px, auto;
-  mask-image: linear-gradient(90deg, #000, transparent 78%);
-}
-
-.founder-page .founder-shift-head {
-  display: grid;
-  grid-template-columns: minmax(0, .58fr) minmax(300px, .42fr);
-  gap: 72px;
-  align-items: end;
-}
-
-.founder-page .founder-shift-copy p {
-  margin: 0 0 22px;
-  color: var(--founder-soft);
-  font-size: 15px;
-  line-height: 1.82;
-}
-
-.founder-page .founder-shift-copy strong {
-  color: var(--founder-text);
-  font-weight: 500;
-}
-
-.founder-page .founder-system {
-  position: relative;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-  margin-top: 78px;
-  padding-bottom: 28px;
-}
-
-.founder-page .founder-system::before {
-  position: absolute;
-  top: 50%;
-  right: 8%;
-  left: 8%;
-  height: 1px;
-  z-index: 0;
-  background: linear-gradient(90deg, transparent, rgba(225, 195, 138, .42), transparent);
-  box-shadow: 0 0 20px rgba(196, 154, 88, .18);
-  content: "";
-  animation: founderPulse 6s ease-in-out infinite;
-}
-
-.founder-page .founder-system-card {
-  position: relative;
-  z-index: 1;
-  min-height: 330px;
-  padding: 29px;
-  border: 1px solid var(--founder-line);
-  background: linear-gradient(160deg, rgba(20, 28, 36, .98), rgba(7, 11, 15, .98));
-  box-shadow: 0 30px 70px rgba(0, 0, 0, .27);
-  transition: transform .35s ease, border-color .35s ease, box-shadow .35s ease;
-}
-
-.founder-page .founder-system-card:nth-child(2) {
-  transform: translateY(18px);
-}
-
-.founder-page .founder-system-card:nth-child(3) {
-  transform: translateY(36px);
-}
-
-.founder-page .founder-system-card:hover {
-  border-color: rgba(225, 195, 138, .44);
-  box-shadow: 0 38px 80px rgba(0, 0, 0, .4), 0 0 45px rgba(196, 154, 88, .06);
-  transform: translateY(-5px);
-}
-
-.founder-page .founder-system-card:nth-child(2):hover {
-  transform: translateY(13px);
-}
-
-.founder-page .founder-system-card:nth-child(3):hover {
-  transform: translateY(31px);
-}
-
-.founder-page .founder-system-role {
-  display: block;
-  color: var(--founder-gold);
-  font-size: 7px;
-  line-height: 1.5;
-  letter-spacing: 1.35px;
-}
-
-.founder-page .founder-system-card h3 {
-  margin: 92px 0 18px;
-  color: var(--founder-text);
-  font-size: clamp(23px, 2vw, 31px);
-  font-weight: 500;
-  line-height: 1.15;
-  letter-spacing: -.025em;
-}
-
-.founder-page .founder-system-card p {
-  margin: 0;
-  color: var(--founder-soft);
-  font-size: 14px;
-  line-height: 1.75;
-}
-
-/* Public verification */
-.founder-page .founder-verification::before {
-  background:
-    radial-gradient(720px 520px at 88% 30%, rgba(196, 154, 88, .08), transparent 72%),
-    linear-gradient(180deg, #06090c, #05080a);
-}
-
-.founder-page .founder-proof-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(330px, .65fr);
-  gap: 18px;
-  margin-top: 66px;
-}
-
-.founder-page .founder-proof-card {
-  --pointer-x: 50%;
-  --pointer-y: 50%;
-  position: relative;
-  display: flex;
-  min-height: 245px;
-  overflow: hidden;
-  flex-direction: column;
-  padding: 31px;
-  border: 1px solid var(--founder-line);
-  background: linear-gradient(150deg, rgba(16, 23, 29, .96), rgba(5, 8, 11, .98));
-  text-decoration: none;
-  transition: transform .3s ease, border-color .3s ease, box-shadow .3s ease;
-}
-
-.founder-page .founder-proof-card::before {
-  position: absolute;
-  inset: 0;
-  opacity: .45;
-  background: radial-gradient(420px circle at var(--pointer-x) var(--pointer-y), rgba(225, 195, 138, .11), transparent 58%);
-  content: "";
-  pointer-events: none;
-  transition: opacity .3s ease;
-}
-
-.founder-page .founder-proof-card:hover,
-.founder-page .founder-proof-card:focus-visible {
-  border-color: rgba(225, 195, 138, .48);
-  box-shadow: 0 34px 80px rgba(0, 0, 0, .38);
-  transform: translateY(-5px);
-}
-
-.founder-page .founder-proof-card:hover::before,
-.founder-page .founder-proof-card:focus-visible::before {
-  opacity: 1;
-}
-
-.founder-page .founder-proof-card--research {
-  min-height: 510px;
-  background:
-    linear-gradient(150deg, rgba(19, 28, 35, .95), rgba(5, 8, 11, .98)),
-    radial-gradient(circle at 20% 10%, rgba(196, 154, 88, .12), transparent 60%);
-}
-
-.founder-page .founder-proof-stack {
-  display: grid;
-  gap: 18px;
-}
-
-.founder-page .founder-proof-status {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  gap: 9px;
-  align-items: center;
-  color: var(--founder-gold);
-  font-size: 7px;
-  line-height: 1.5;
-  letter-spacing: 1.25px;
-}
-
-.founder-page .founder-proof-status::before {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #7fbaa1;
-  box-shadow: 0 0 12px rgba(127, 186, 161, .6);
-  content: "";
-}
-
-.founder-page .founder-proof-card h3 {
-  position: relative;
-  z-index: 1;
-  max-width: 620px;
-  margin: auto 0 18px;
-  color: var(--founder-text);
-  font-size: clamp(25px, 2.35vw, 36px);
-  font-weight: 500;
-  line-height: 1.16;
-  letter-spacing: -.03em;
-}
-
-.founder-page .founder-proof-card p {
-  position: relative;
-  z-index: 1;
-  max-width: 640px;
-  margin: 0;
-  color: var(--founder-soft);
-  font-size: 14px;
-  line-height: 1.76;
-}
-
-.founder-page .founder-proof-cta {
-  position: relative;
-  z-index: 1;
-  align-self: flex-start;
-  margin-top: 28px;
-  padding-bottom: 7px;
-  border-bottom: 1px solid rgba(225, 195, 138, .50);
-  color: var(--founder-gold-light);
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 1.15px;
-  text-transform: uppercase;
-}
-
-/* Founding doctrine: second ivory breath */
-.founder-page .founder-doctrine {
-  padding: 112px 0;
-  border-color: rgba(15, 21, 27, .14);
-  background: var(--founder-ivory);
-  color: #10151a;
-  text-align: center;
-}
-
-.founder-page .founder-doctrine .founder-kicker {
-  color: #76592e;
-}
-
-.founder-page .founder-doctrine blockquote {
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 0;
-  border: 0;
-  color: #12171c;
-  font: 500 clamp(41px, 5vw, 74px)/1.13 Montserrat, sans-serif;
-  letter-spacing: -.045em;
-}
-
-.founder-page .founder-doctrine blockquote span {
-  color: #9a7340;
-  font-style: italic;
-}
-
-.founder-page .founder-doctrine p {
-  max-width: 820px;
-  margin: 36px auto 0;
-  color: #555c60;
-  font-size: 14px;
-  line-height: 1.82;
-}
-
-/* Conversion */
-.founder-page .founder-contact {
-  padding: 132px 0 118px;
-  background:
-    radial-gradient(780px 560px at 76% 50%, rgba(196, 154, 88, .12), rgba(49, 62, 73, .08) 40%, transparent 72%),
-    linear-gradient(180deg, #05080b, #030507);
-}
-
-.founder-page .founder-contact::before {
-  background:
-    radial-gradient(ellipse 70% 52% at 100% 50%, transparent 0 67%, rgba(197, 176, 125, .11) 67.2% 67.35%, transparent 67.55%),
-    radial-gradient(ellipse 88% 66% at 100% 50%, transparent 0 70%, rgba(197, 176, 125, .07) 70.2% 70.32%, transparent 70.52%);
-}
-
-.founder-page .founder-contact-grid {
-  display: grid;
-  grid-template-columns: minmax(0, .46fr) minmax(520px, .54fr);
-  gap: clamp(48px, 6vw, 92px);
-  align-items: start;
-}
-
-.founder-page .founder-contact .founder-section-title {
-  max-width: 880px;
-}
-
-.founder-page .founder-contact-aside {
-  position: relative;
-  overflow: hidden;
-  padding: clamp(29px, 3vw, 42px);
-  border: 1px solid var(--founder-line);
-  background:
-    radial-gradient(520px 340px at 96% 0%, rgba(196, 154, 88, .10), transparent 65%),
-    rgba(8, 12, 16, .86);
-  box-shadow: 0 34px 90px rgba(0, 0, 0, .38), inset 0 1px 0 rgba(255, 255, 255, .025);
-  backdrop-filter: blur(14px);
-}
-
-.founder-page .founder-contact-aside::before {
-  position: absolute;
-  inset: 12px;
-  border: 1px solid rgba(225, 195, 138, .055);
-  content: "";
-  pointer-events: none;
-}
-
-.founder-page .founder-contact-aside > .founder-contact-copy {
-  position: relative;
-  z-index: 1;
-  margin: 0;
-  color: var(--founder-soft);
-  font-size: 14px;
-  line-height: 1.78;
-  text-align: justify;
-  text-justify: inter-word;
-}
-
-.founder-page .founder-signal-head {
-  position: relative;
-  z-index: 1;
-  margin-top: 30px;
-  padding-top: 27px;
-  border-top: 1px solid rgba(225, 195, 138, .16);
-}
-
-.founder-page .founder-contact-aside .founder-form-kicker {
-  margin: 0 0 15px;
-  color: var(--founder-gold);
-  font: 600 8px/1.5 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1.7px;
-}
-
-.founder-page .founder-contact-aside h3 {
-  max-width: 540px;
-  margin: 0;
-  color: var(--founder-text);
-  font: 500 clamp(30px, 3vw, 44px)/1.12 Orbitron, Montserrat, sans-serif;
-  letter-spacing: -.025em;
-}
-
-.founder-page .founder-contact-aside .founder-contact-intro {
-  max-width: 540px;
-  margin: 14px 0 0;
-  color: var(--founder-soft);
-  font-size: 15px;
-  line-height: 1.65;
-  text-align: left;
-}
-
-.founder-page .founder-contact-email {
-  position: relative;
-  z-index: 1;
-  display: inline-flex;
-  min-height: 38px;
-  align-items: center;
-  margin-top: 20px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid rgba(225, 195, 138, .50);
-  color: var(--founder-gold-light);
-  font-size: 10px;
-  text-decoration: none;
-}
-
-.founder-page .founder-contact-form {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px;
-  margin-top: 30px;
-  scroll-margin-top: 100px;
-}
-
-.founder-page .founder-contact-form[hidden] {
-  display: none;
-}
-
-.founder-page .founder-contact-form label {
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  gap: 8px;
-  color: #9fa4a3;
-  font: 600 10px/1.4 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1.05px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-contact-form input,
-.founder-page .founder-contact-form textarea {
-  width: 100%;
-  height: 54px;
-  padding: 0 14px;
-  border: 1px solid #29302f;
-  border-radius: 0;
-  outline: none;
-  background: #070a0b;
-  color: #e2ded5;
-  font: 500 13px/1 Montserrat, sans-serif;
-  text-align: left;
-  text-transform: none;
-  transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
-}
-
-.founder-page .founder-contact-form input:focus,
-.founder-page .founder-contact-form textarea:focus {
-  border-color: var(--founder-gold);
-  background: #090d0e;
-  box-shadow: 0 0 0 3px rgba(196, 154, 88, .08);
-}
-
-.founder-page .founder-contact-form .founder-form-wide,
-.founder-page .founder-contact-form .founder-form-consent,
-.founder-page .founder-contact-form .founder-form-error,
-.founder-page .founder-contact-form .founder-form-note {
-  grid-column: 1 / -1;
-}
-
-.founder-page .founder-contact-form textarea {
-  min-height: 104px;
-  padding: 12px;
-  line-height: 1.55;
-  resize: vertical;
-}
-
-.founder-page .founder-contact-form .founder-form-consent {
-  display: flex;
-  flex-direction: row;
-  gap: 11px;
-  align-items: flex-start;
-  color: #8f9798;
-  font-family: Montserrat, sans-serif;
-  letter-spacing: 0;
-  text-transform: none;
-}
-
-.founder-page .founder-contact-form .founder-form-consent input {
-  flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
-  padding: 0;
-  accent-color: var(--founder-gold);
-}
-
-.founder-page .founder-contact-form .founder-form-consent span {
-  display: grid;
-  gap: 4px;
-}
-
-.founder-page .founder-contact-form .founder-form-consent b {
-  color: #b4b8b6;
-  font: 600 10px/1.4 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-}
-
-.founder-page .founder-contact-form .founder-form-consent small {
-  color: #747c7d;
-  font: 500 12px/1.55 Montserrat, sans-serif;
-  letter-spacing: 0;
-}
-
-.founder-page .founder-form-submit {
-  display: inline-flex;
-  width: 100%;
-  min-height: 56px;
-  justify-content: space-between;
-  gap: 22px;
-  align-items: center;
-  padding: 14px 17px;
-  border: 1px solid #d0b06b;
-  background: linear-gradient(110deg, #ad8747, #dfc17e);
-  color: #090b0d;
-  font: 700 10px/1.3 Montserrat, sans-serif;
-  letter-spacing: 1.25px;
-  text-transform: uppercase;
-  cursor: pointer;
-  box-shadow: 0 16px 42px rgba(173, 135, 71, .14);
-  transition: transform .2s ease, filter .2s ease, opacity .2s ease;
-}
-
-.founder-page .founder-form-submit:hover,
-.founder-page .founder-form-submit:focus-visible {
-  filter: brightness(1.08);
-  transform: translateY(-2px);
-}
-
-.founder-page .founder-form-submit:disabled {
-  opacity: .65;
-  cursor: wait;
-  transform: none;
-}
-
-.founder-page .founder-form-error,
-.founder-page .founder-form-note {
-  display: block;
-  text-align: left;
-  text-transform: none;
-}
-
-.founder-page .founder-form-error {
-  color: #e4a38e;
-  font-size: 10px;
-  line-height: 1.5;
-}
-
-.founder-page .founder-form-error:empty {
-  display: none;
-}
-
-.founder-page .founder-form-note {
-  color: #626b6c;
-  font-size: 9px;
-  line-height: 1.55;
-}
-
-.founder-page .founder-form-success {
-  position: relative;
-  z-index: 1;
-  margin-top: 28px;
-  padding: 23px;
-  border-left: 2px solid var(--founder-gold);
-  background: rgba(196, 154, 88, .045);
-}
-
-.founder-page .founder-form-success[hidden] {
-  display: none;
-}
-
-.founder-page .founder-form-success strong {
-  color: var(--founder-gold-light);
-  font: 600 14px/1.4 Orbitron, Montserrat, sans-serif;
-  letter-spacing: 1px;
-}
-
-.founder-page .founder-form-success p {
-  margin-top: 11px;
-  color: var(--founder-soft);
-  font-size: 12px;
-  line-height: 1.65;
-  text-align: left;
-}
-
-.founder-page .founder-form-noscript {
-  position: relative;
-  z-index: 1;
-  margin-top: 22px !important;
-  text-align: left !important;
-}
-
-.founder-page .founder-form-noscript a {
-  color: var(--founder-gold-light);
-}
-
-/* Motion progressively enabled by founder-reputation.js */
-.motion-ready .founder-page [data-reveal] {
-  opacity: 0;
-  translate: 0 30px;
-  transition: opacity .75s cubic-bezier(.2, .7, .2, 1), translate .8s cubic-bezier(.2, .7, .2, 1);
-}
-
-.motion-ready .founder-page [data-reveal="left"] {
-  translate: -28px 0;
-}
-
-.motion-ready .founder-page [data-reveal="right"] {
-  translate: 28px 0;
-}
-
-.motion-ready .founder-page [data-reveal].is-visible {
-  opacity: 1;
-  translate: 0 0;
-}
-
-.motion-ready .founder-page [data-reveal-group] > * {
-  opacity: 0;
-  translate: 0 24px;
-  transition: opacity .65s cubic-bezier(.2, .7, .2, 1), translate .72s cubic-bezier(.2, .7, .2, 1);
-}
-
-.motion-ready .founder-page [data-reveal-group].is-visible > * {
-  opacity: 1;
-  translate: 0 0;
-}
-
-.motion-ready .founder-page [data-reveal-group].is-visible > *:nth-child(2) { transition-delay: .10s; }
-.motion-ready .founder-page [data-reveal-group].is-visible > *:nth-child(3) { transition-delay: .20s; }
-.motion-ready .founder-page [data-reveal-group].is-visible > *:nth-child(4) { transition-delay: .30s; }
-.motion-ready .founder-page [data-reveal-group].is-visible > *:nth-child(5) { transition-delay: .40s; }
-
-@keyframes founderHalo {
-  to { transform: translate3d(-28px, 24px, 0) scale(1.04); }
-}
-
-@keyframes founderPortraitLight {
-  to { background-position: 0 0, -110% 0; }
-}
-
-@keyframes founderRail {
-  to { transform: translateX(-50%); }
-}
-
-@keyframes founderPulse {
-  0%, 100% { opacity: .32; transform: scaleX(.82); }
-  50% { opacity: 1; transform: scaleX(1); }
-}
-
-@media (max-width: 1080px) {
-  .founder-page .founder-hero-inner {
-    grid-template-columns: minmax(0, 1fr) minmax(330px, .62fr);
-  }
-
-  .founder-page .founder-portrait-stat--top { right: -12px; }
-  .founder-page .founder-portrait-stat--bottom { left: -18px; }
-  .founder-page .founder-card { padding: 25px; }
-}
-
-@media (max-width: 920px) {
-  .founder-page .founder-hero-inner,
-  .founder-page .founder-intro-grid,
-  .founder-page .founder-origin-head,
-  .founder-page .founder-method-grid,
-  .founder-page .founder-shift-head,
-  .founder-page .founder-contact-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .founder-page .founder-hero-inner {
-    padding-top: 74px;
-    row-gap: 0;
-  }
-
-  .founder-page .founder-intro-grid,
-  .founder-page .founder-origin-head,
-  .founder-page .founder-method-grid,
-  .founder-page .founder-shift-head,
-  .founder-page .founder-contact-grid {
-    row-gap: 40px;
-  }
-
-  .founder-page .founder-portrait-stage {
-    width: min(78vw, 450px);
-    margin: 28px auto 35px;
-  }
-
-  .founder-page .founder-credibility {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .founder-page .founder-credibility span:nth-child(2) { border-right: 0; }
-  .founder-page .founder-credibility span:nth-child(-n+2) { border-bottom: 1px solid var(--founder-line); }
-  .founder-page .founder-card-grid,
-  .founder-page .founder-system { grid-template-columns: 1fr; }
-  .founder-page .founder-card { min-height: 250px; }
-  .founder-page .founder-system::before { display: none; }
-  .founder-page .founder-system-card,
-  .founder-page .founder-system-card:nth-child(2),
-  .founder-page .founder-system-card:nth-child(3),
-  .founder-page .founder-system-card:hover,
-  .founder-page .founder-system-card:nth-child(2):hover,
-  .founder-page .founder-system-card:nth-child(3):hover { transform: none; }
-  .founder-page .founder-system-card { min-height: 260px; }
-  .founder-page .founder-system-card h3 { margin-top: 60px; }
-  .founder-page .founder-proof-layout { grid-template-columns: 1fr; }
-  .founder-page .founder-proof-card--research { min-height: 420px; }
-}
-
-@media (max-width: 720px) {
-  .founder-page .founder-chapter { padding: 82px 0; }
-  .founder-page .founder-section-title { font-size: 39px; }
-  .founder-page .founder-hero { min-height: auto; }
-  .founder-page .founder-hero-inner { min-height: auto; padding: 66px 0 48px; }
-  .founder-page .founder-hero h1 { font-size: clamp(40px, 12.5vw, 57px); line-height: 1.01; }
-  .founder-page .founder-kicker { font-size: 10px; letter-spacing: 1.7px; }
-  .founder-page .founder-hero-lead { margin-top: 26px; }
-  .founder-page .founder-actions { align-items: stretch; }
-  .founder-page .founder-actions .btn { width: 100%; font-size: 11px; }
-  .founder-page .founder-text-link { width: auto; font-size: 11px; }
-  .founder-page .founder-portrait-stage { width: min(86vw, 390px); margin-top: 48px; }
-  .founder-page .founder-portrait-stage::before { inset: -14px 16px 24px -14px; }
-  .founder-page .founder-portrait-stage::after { inset: 24px -14px -14px 20px; }
-  .founder-page .founder-portrait-stat { min-width: 125px; padding: 12px 13px; }
-  .founder-page .founder-portrait-stat--top { top: 6%; right: -8px; }
-  .founder-page .founder-portrait-stat--bottom { bottom: 20%; left: -8px; }
-  .founder-page .founder-portrait-stat strong { font-size: 12px; }
-  .founder-page .founder-portrait-stat span { font-size: 10px; }
-  .founder-page .founder-portrait-label { right: 18px; bottom: 17px; left: 18px; }
-  .founder-page .founder-portrait-label > span > span { font-size: 10px; }
-  .founder-page .founder-portrait-mark { display: none; }
-  .founder-page .founder-credibility { grid-template-columns: 1fr; }
-  .founder-page .founder-credibility span { border-right: 0; border-bottom: 1px solid var(--founder-line); }
-  .founder-page .founder-credibility span:last-child { border-bottom: 0; }
-  .founder-page .founder-origin-map { grid-template-columns: 1fr; }
-  .founder-page .founder-origin-event { min-height: 0; padding: 31px 0; }
-  .founder-page .founder-origin-event:first-child,
-  .founder-page .founder-origin-event:last-child { border: 0; }
-  .founder-page .founder-origin-event:first-child { border-bottom: 1px solid rgba(15, 21, 27, .16); }
-  .founder-page .founder-origin-event h3 { margin-top: 34px; }
-  .founder-page .founder-origin-bridge { min-height: 120px; }
-  .founder-page .founder-origin-bridge::before { top: 0; right: auto; bottom: 0; left: 50%; width: 1px; height: auto; }
-  .founder-page .founder-origin-bridge span { width: 78px; height: 78px; }
-  .founder-page .founder-origin-conclusion { margin-top: 38px; font-size: 25px; }
-  .founder-page .founder-card-grid { margin-top: 45px; }
-  .founder-page .founder-card { min-height: 260px; padding: 24px; }
-  .founder-page .founder-credibility span,
-  .founder-page .founder-number,
-  .founder-page .founder-system-role,
-  .founder-page .founder-proof-status,
-  .founder-page .founder-proof-cta { font-size: 10px; }
-  .founder-page .founder-system { margin-top: 52px; }
-  .founder-page .founder-system-card { padding: 24px; }
-  .founder-page .founder-proof-layout { margin-top: 48px; }
-  .founder-page .founder-proof-card,
-  .founder-page .founder-proof-card--research { min-height: 330px; padding: 24px; }
-  .founder-page .founder-doctrine { padding: 82px 0; }
-  .founder-page .founder-doctrine blockquote { font-size: 40px; }
-  .founder-page .founder-contact { padding: 92px 0 86px; }
-  .founder-page .founder-contact-grid { gap: 48px; }
-  .founder-page .founder-contact-aside { padding: 25px 21px; }
-  .founder-page .founder-contact-form { grid-template-columns: 1fr; }
-  .founder-page .founder-contact-form .founder-form-wide,
-  .founder-page .founder-contact-form .founder-form-consent,
-  .founder-page .founder-contact-form .founder-form-error,
-  .founder-page .founder-contact-form .founder-form-note { grid-column: auto; }
-  .founder-page .founder-contact-email { font-size: 10px; }
-}
-
-@media (hover: none), (pointer: coarse) {
-  .founder-page .founder-card:hover,
-  .founder-page .founder-proof-card:hover,
-  .founder-page .founder-system-card:hover { transform: none; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html:has(body.founder-page) {
-    scroll-behavior: auto !important;
-  }
-
-  .founder-page *,
-  .founder-page *::before,
-  .founder-page *::after {
-    scroll-behavior: auto !important;
-    animation-duration: .001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: .001ms !important;
-  }
-
-  .motion-ready .founder-page [data-reveal],
-  .motion-ready .founder-page [data-reveal-group] > * {
-    opacity: 1;
-    translate: none;
-  }
-
-  .founder-page .founder-actions .btn:hover,
-  .founder-page .founder-actions .btn:focus-visible,
-  .founder-page .founder-card:hover,
-  .founder-page .founder-proof-card:hover,
-  .founder-page .founder-proof-card:focus-visible,
-  .founder-page .founder-system-card:hover,
-  .founder-page .founder-system-card:nth-child(2):hover,
-  .founder-page .founder-system-card:nth-child(3):hover {
-    transform: none !important;
-  }
-}
-
-/* Editorial prose — justified where the measure is wide enough to stay elegant. */
-@media (min-width: 921px) {
-  .founder-page .founder-hero-lead,
-  .founder-page .founder-section-lead,
-  .founder-page .founder-origin-event p,
-  .founder-page .founder-method-copy p,
-  .founder-page .founder-shift-copy p,
-  .founder-page .founder-doctrine p,
-  .founder-page .founder-contact-aside > .founder-contact-copy {
-    text-align: justify;
-    text-align-last: left;
-    text-justify: inter-word;
-    hyphens: auto;
-  }
+.founder-method-grid{display:grid;grid-template-columns:minmax(0,.72fr) minmax(520px,1.28fr);gap:92px;align-items:start}
+.founder-method-intro{margin-top:29px}
+.founder-question-grid{display:grid;grid-template-columns:1fr 1fr;border-top:1px solid var(--founder-line)}
+.founder-question{display:grid;grid-template-columns:56px 1fr;min-height:112px;align-items:center;border-right:1px solid var(--founder-line);border-bottom:1px solid var(--founder-line)}
+.founder-question:nth-child(2n){border-right:0}
+.founder-question b{display:grid;min-height:100%;place-items:center;border-right:1px solid var(--founder-line);color:var(--founder-gold);font:600 .68rem Orbitron,sans-serif}
+.founder-question span{padding:22px 24px;color:#d4d2cb;font-size:.94rem;line-height:1.55}
+
+/* Origin */
+.founder-origin-grid{display:grid;grid-template-columns:minmax(0,.85fr) minmax(470px,1.15fr);gap:90px;align-items:start}
+.founder-origin blockquote{margin:38px 0 0;max-width:650px;color:var(--founder-pale);font:500 clamp(1.35rem,2.35vw,2.25rem)/1.42 Orbitron,Montserrat,sans-serif;letter-spacing:-.02em}
+.founder-origin-copy>p{margin:0 0 34px;color:var(--founder-soft);font-size:.95rem;line-height:1.9}
+.founder-origin-points{border-top:1px solid var(--founder-line)}
+.founder-origin-points>div{display:grid;grid-template-columns:50px minmax(180px,.48fr) 1fr;gap:24px;align-items:start;padding:24px 0;border-bottom:1px solid var(--founder-line)}
+.founder-origin-points span{color:var(--founder-gold);font:600 .65rem Orbitron,sans-serif}
+.founder-origin-points strong{color:var(--founder-pale);font:600 .85rem/1.55 Orbitron,Montserrat,sans-serif}
+.founder-origin-points p{margin:0;color:var(--founder-soft);font-size:.86rem;line-height:1.75}
+
+/* Method to infrastructure */
+.founder-chain{display:grid;grid-template-columns:1fr auto 1fr auto 1fr auto 1fr;gap:18px;align-items:stretch;margin-top:43px}
+.founder-chain article{min-height:245px;padding:29px 27px;border:1px solid var(--founder-line);background:#080b0f}
+.founder-chain article>span{color:var(--founder-gold);font:600 .59rem Orbitron,sans-serif;letter-spacing:.12em}
+.founder-chain h3{margin:27px 0 16px;color:var(--founder-pale);font-size:1rem;line-height:1.4}
+.founder-chain p{margin:0;color:var(--founder-soft);font-size:.86rem;line-height:1.78}
+.founder-chain>b{display:grid;place-items:center;color:var(--founder-gold);font-size:1.3rem}
+
+/* Paris × Sydney */
+.founder-axis-grid{display:grid;grid-template-columns:1fr 90px 1fr;border:1px solid var(--founder-line)}
+.founder-axis-grid article{min-height:390px;padding:37px 39px;background:#080b0f}
+.founder-axis-grid article:first-child{border-right:1px solid var(--founder-line)}
+.founder-axis-grid article:last-child{border-left:1px solid var(--founder-line)}
+.founder-axis-x{display:grid;place-items:center;color:var(--founder-gold);font:500 2.5rem Orbitron,sans-serif;background:#0d1217}
+.founder-axis-city{color:var(--founder-gold);font-size:.7rem;letter-spacing:.17em}
+.founder-axis-grid h3{margin:29px 0 17px;color:var(--founder-pale);font-size:1.08rem;line-height:1.45}
+.founder-axis-grid p,.founder-axis-grid li{color:var(--founder-soft);font-size:.9rem;line-height:1.82}
+.founder-axis-grid ul{margin:25px 0 0;padding:21px 0 0 20px;border-top:1px solid rgba(255,255,255,.07)}
+.founder-axis-grid li{margin:0 0 8px;padding-left:4px}
+.founder-axis-note{margin:19px 0 0;color:var(--founder-muted);font-size:.72rem;line-height:1.7}
+
+/* Public proof */
+.founder-proof-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));border-block:1px solid var(--founder-line)}
+.founder-proof-card{position:relative;display:flex;min-height:335px;flex-direction:column;padding:31px 27px 29px;overflow:hidden;border-right:1px solid var(--founder-line);color:inherit;text-decoration:none;background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96))}
+.founder-proof-card:last-child{border-right:0}
+.founder-proof-status{position:relative;z-index:1;color:var(--founder-gold);font-size:.59rem;letter-spacing:.12em}
+.founder-proof-card h3{position:relative;z-index:1;margin:31px 0 17px;color:var(--founder-pale);font-size:.94rem;line-height:1.45}
+.founder-proof-card p{position:relative;z-index:1;margin:0 0 27px;color:var(--founder-soft);font-size:.86rem;line-height:1.78}
+.founder-proof-cta{position:relative;z-index:1;align-self:flex-start;margin-top:auto;padding-bottom:7px;border-bottom:1px solid rgba(225,195,138,.48);color:var(--founder-pale);font:600 .57rem/1.45 Orbitron,Montserrat,sans-serif;letter-spacing:.09em;text-transform:uppercase}
+.founder-proof-card:hover{background:#121820}
+.founder-proof-card:hover .founder-proof-cta{color:#efd496;border-color:#efd496}
+
+/* Contact and HubSpot submission */
+.founder-contact-grid{display:grid;grid-template-columns:minmax(0,.86fr) minmax(520px,1.14fr);gap:88px;align-items:start}
+.founder-contact-copy{max-width:690px;margin-top:30px}
+.founder-contact-aside{padding:34px;border:1px solid var(--founder-line);background:#0d1217}
+.founder-signal-head{padding-bottom:27px;border-bottom:1px solid var(--founder-line)}
+.founder-form-kicker{margin:0 0 13px;color:var(--founder-gold);font-size:.61rem;letter-spacing:.13em}
+.founder-signal-head h3{margin:0;color:var(--founder-pale);font-size:1.05rem;line-height:1.45;letter-spacing:.02em}
+.founder-contact-intro{margin:16px 0 0;color:var(--founder-soft);font-size:.86rem;line-height:1.78}
+.founder-contact-form{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:27px}
+.founder-contact-form label{display:grid;gap:8px;color:#aeb4b4;font-size:.68rem;font-weight:600;letter-spacing:.04em}
+.founder-contact-form input,.founder-contact-form textarea{width:100%;border:1px solid rgba(157,166,170,.28);border-radius:0;outline:0;background:#05080b;color:var(--founder-ivory);padding:13px 14px;font:500 .86rem/1.5 Montserrat,sans-serif}
+.founder-contact-form textarea{min-height:122px;resize:vertical}
+.founder-contact-form input:focus,.founder-contact-form textarea:focus{border-color:var(--founder-gold);box-shadow:0 0 0 2px rgba(196,154,88,.08)}
+.founder-form-wide,.founder-form-consent,.founder-form-submit,.founder-form-error,.founder-form-note{grid-column:1/-1}
+.founder-form-consent{display:grid!important;grid-template-columns:auto 1fr;gap:12px!important;align-items:start;padding:14px 0 0;border-top:1px solid rgba(255,255,255,.06)}
+.founder-form-consent input{width:16px;height:16px;margin-top:2px;accent-color:var(--founder-gold)}
+.founder-form-consent span{display:block}
+.founder-form-consent b{display:block;color:#d4d3cc;font-size:.69rem;line-height:1.45}
+.founder-form-consent small{display:block;margin-top:4px;color:var(--founder-muted);font-size:.66rem;line-height:1.55}
+.founder-form-submit{display:flex;min-height:49px;align-items:center;justify-content:space-between;padding:14px 17px;border:1px solid #d0b06b;border-radius:0;background:linear-gradient(110deg,#ad8747,#dfc17e);color:#0a0c0e;cursor:pointer;font:700 .66rem/1.2 Orbitron,Montserrat,sans-serif;letter-spacing:.12em}
+.founder-form-submit:disabled{opacity:.55;cursor:wait}
+.founder-form-error{min-height:1.2em;color:#ff8c8c;font-size:.68rem}
+.founder-form-note{color:var(--founder-muted);font-size:.65rem;line-height:1.55}
+.founder-contact-email{display:inline-flex;margin-top:23px;padding-bottom:7px;border-bottom:1px solid rgba(225,195,138,.43);color:var(--founder-pale);font-size:.72rem;text-decoration:none}
+.founder-contact-email:hover{border-color:#efd496;color:#efd496}
+.founder-form-success{margin-top:26px;padding:24px;border-left:2px solid var(--green);background:rgba(98,185,156,.06)}
+.founder-form-success strong{color:#9bd4be;font:600 .72rem Orbitron,sans-serif;letter-spacing:.1em}
+.founder-form-success p{margin:10px 0 0;color:var(--founder-soft);font-size:.86rem}
+.founder-form-noscript{color:var(--founder-soft);font-size:.83rem}
+
+/* Progressive reveal: restrained. */
+html.motion-ready .founder-page [data-reveal],html.motion-ready .founder-page [data-reveal-group]{opacity:0;transform:translateY(18px);transition:opacity .7s ease,transform .7s ease}
+html.motion-ready .founder-page [data-reveal="left"]{transform:translate3d(-22px,12px,0)}
+html.motion-ready .founder-page [data-reveal="right"]{transform:translate3d(22px,12px,0)}
+html.motion-ready .founder-page [data-reveal].is-visible,html.motion-ready .founder-page [data-reveal-group].is-visible{opacity:1;transform:none}
+
+/* Responsive */
+@media(max-width:1120px){
+  .founder-hero-inner{grid-template-columns:1fr minmax(360px,.62fr)}
+  .founder-signal-grid,.founder-integrity-grid,.founder-now-grid,.founder-proof-grid{grid-template-columns:repeat(2,1fr)}
+  .founder-signal-card:nth-child(2),.founder-integrity-card:nth-child(2),.founder-now-card:nth-child(2),.founder-proof-card:nth-child(2){border-right:0}
+  .founder-signal-card,.founder-integrity-card,.founder-now-card,.founder-proof-card{border-bottom:1px solid var(--founder-line)}
+  .founder-signal-card:nth-last-child(-n+2),.founder-integrity-card:nth-last-child(-n+2),.founder-now-card:nth-last-child(-n+2),.founder-proof-card:nth-last-child(-n+2){border-bottom:0}
+  .founder-chain{grid-template-columns:1fr 30px 1fr}
+  .founder-chain article:nth-of-type(3){grid-column:1}
+  .founder-chain article:nth-of-type(4){grid-column:3}
+  .founder-chain>b:nth-of-type(2){display:none}
+}
+@media(max-width:980px){
+  .founder-hero-inner{grid-template-columns:1fr;padding-top:72px}
+  .founder-portrait-stage{width:min(520px,100%);margin:10px auto 0}
+  .founder-credibility{grid-template-columns:repeat(2,1fr)}
+  .founder-credibility span:nth-child(2){border-right:0}
+  .founder-credibility span:nth-child(-n+2){border-bottom:1px solid var(--founder-line)}
+  .founder-heading-grid,.founder-method-grid,.founder-origin-grid,.founder-contact-grid{grid-template-columns:1fr;gap:34px}
+  .founder-heading-grid{margin-bottom:36px}
+  .founder-modes-grid{grid-template-columns:1fr}
+  .founder-mode-card{border-right:0;border-bottom:1px solid var(--founder-line)}
+  .founder-mode-card:last-child{border-bottom:0}
+  .founder-axis-grid{grid-template-columns:1fr}
+  .founder-axis-grid article:first-child,.founder-axis-grid article:last-child{border:0}
+  .founder-axis-grid article:first-child{border-bottom:1px solid var(--founder-line)}
+  .founder-axis-x{min-height:70px}
+  .founder-chain{grid-template-columns:1fr}
+  .founder-chain>b{transform:rotate(90deg);min-height:24px}
+  .founder-chain article:nth-of-type(3),.founder-chain article:nth-of-type(4){grid-column:auto}
+  .founder-chain>b:nth-of-type(2){display:grid}
+}
+@media(max-width:760px){
+  .founder-wrap{width:calc(100% - 44px)}
+  .founder-hero{min-height:auto}
+  .founder-hero-inner{min-height:auto;padding:65px 22px 72px}
+  .founder-hero h1{font-size:43px}
+  .founder-hero h1 span{font-size:.45em}
+  .founder-portrait-stage{width:100%}
+  .founder-credibility{grid-template-columns:1fr}
+  .founder-credibility span{border-right:0;border-bottom:1px solid var(--founder-line)}
+  .founder-credibility span:last-child{border-bottom:0}
+  .founder-chapter{padding:75px 0}
+  .founder-section-title{font-size:clamp(2rem,11vw,3.3rem)}
+  .founder-signal-grid,.founder-integrity-grid,.founder-now-grid,.founder-proof-grid{grid-template-columns:1fr}
+  .founder-signal-card,.founder-integrity-card,.founder-now-card,.founder-proof-card{min-height:auto;border-right:0;border-bottom:1px solid var(--founder-line)!important}
+  .founder-signal-card:last-child,.founder-integrity-card:last-child,.founder-now-card:last-child,.founder-proof-card:last-child{border-bottom:0!important}
+  .founder-question-grid{grid-template-columns:1fr}
+  .founder-question:nth-child(n){border-right:0}
+  .founder-origin-points>div{grid-template-columns:42px 1fr}
+  .founder-origin-points p{grid-column:2}
+  .founder-contact-aside{padding:25px 22px}
+  .founder-contact-form{grid-template-columns:1fr}
+  .founder-contact-form label{grid-column:1}
+  .founder-axis-grid article{padding:30px 26px}
+}
+@media(max-width:480px){
+  .founder-hero h1{font-size:38px}
+  .founder-crossline{gap:6px}
+  .founder-crossline span{font-size:6px}
+  .founder-actions{align-items:stretch}
+  .founder-actions .btn{width:100%}
+  .founder-text-link{justify-content:center;width:100%}
+  .founder-portrait-label{right:24px;bottom:23px;left:24px}
+}
+@media(prefers-reduced-motion:reduce){
+  .founder-portrait-card{transition:none}
+  html.motion-ready .founder-page [data-reveal],html.motion-ready .founder-page [data-reveal-group]{opacity:1;transform:none;transition:none}
 }

--- a/docs/fr/gersende-de-parcey.html
+++ b/docs/fr/gersende-de-parcey.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050709">
-  <title>Gersende de Parcey | Executive Advisor &amp; Fondatrice d’OpenProof</title>
-  <meta name="description" content="Gersende de Parcey reconstruit la mécanique réelle des situations critiques et rend les faits, les responsabilités et les décisions lisibles, traçables et vérifiables.">
+  <title>Gersende de Parcey | Fondatrice d’OpenProof & Créatrice de TruthX Engine</title>
+  <meta name="description" content="Gersende de Parcey, fondatrice d’OpenProof et créatrice de TruthX Engine, conçoit des systèmes d’intégrité factuelle, décisionnelle et probatoire pour les situations complexes.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/fr/gersende-de-parcey.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html">
@@ -14,40 +14,41 @@
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preload" as="image" href="/images/gersende-de-parcey-full.svg">
   <meta property="og:type" content="profile">
-  <meta property="og:title" content="Gersende de Parcey | Executive Advisor &amp; Fondatrice d’OpenProof">
-  <meta property="og:description" content="Reconstruire la mécanique réelle des situations critiques — puis rendre cette reconstruction lisible, traçable et vérifiable.">
+  <meta property="og:title" content="Gersende de Parcey | Fondatrice d’OpenProof & Créatrice de TruthX Engine">
+  <meta property="og:description" content="Rendre le réel démontrable — avant, pendant et après la crise.">
   <meta property="og:url" content="https://rpo.openproof.net/fr/gersende-de-parcey.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/gersende-de-parcey.png?v=20260731-1">
   <meta property="og:locale" content="fr_FR">
   <meta property="og:locale:alternate" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Gersende de Parcey | Executive Advisor &amp; Fondatrice d’OpenProof">
-  <meta name="twitter:description" content="Reconstruire la mécanique réelle des situations critiques — puis rendre cette reconstruction lisible, traçable et vérifiable.">
+  <meta name="twitter:title" content="Gersende de Parcey | Fondatrice d’OpenProof & Créatrice de TruthX Engine">
+  <meta name="twitter:description" content="Rendre le réel démontrable — avant, pendant et après la crise.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/gersende-de-parcey.png?v=20260731-1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-3">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260805-4">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Gersende de Parcey",
     "url": "https://rpo.openproof.net/fr/gersende-de-parcey.html",
-    "jobTitle": "Executive Advisor, fondatrice d’OpenProof et créatrice de TruthX Engine",
-    "sameAs": [
-      "https://www.linkedin.com/in/gryard/"
-    ],
+    "jobTitle": "Fondatrice d’OpenProof, créatrice de TruthX Engine et Executive Advisor",
+    "sameAs": ["https://www.linkedin.com/in/gryard/"],
     "image": "https://rpo.openproof.net/images/gersende-de-parcey-full.svg",
-    "description": "Executive advisor, fondatrice d’OpenProof et créatrice de TruthX Engine, transformant une méthode de vingt ans de reconstruction du réel organisationnel en infrastructure probatoire déterministe.",
+    "description": "Fondatrice d’OpenProof et créatrice de TruthX Engine, un moteur universel d’intégrité factuelle, décisionnelle et probatoire issu de vingt ans de gouvernance, transformation et gestion de crise.",
     "knowsAbout": [
+      "factual integrity",
+      "decision integrity",
+      "probative integrity",
       "Organizational Reality Engineering",
-      "infrastructure probatoire",
-      "reconstruction de décision",
-      "provenance des preuves",
-      "gouvernance",
-      "Registered Probative Object"
+      "governance",
+      "decision reconstruction",
+      "evidence provenance",
+      "Registered Probative Object",
+      "France-Australia research and deployment"
     ],
     "worksFor": {
       "@type": "Organization",
@@ -82,264 +83,161 @@
   </nav>
 
   <main id="main">
-    <header class="founder-hero cosmos">
+    <header class="founder-hero cosmos" id="overview">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap founder-hero-inner">
+      <div class="founder-hero-inner">
         <div class="founder-hero-copy" data-reveal="left">
-          <p class="founder-kicker">Gersende de Parcey · Executive Advisor · Fondatrice d’OpenProof</p>
-          <h1>La vérité ne suffit pas.<span>Elle doit pouvoir résister au pouvoir du récit.</span></h1>
-          <p class="founder-hero-lead">Quand les faits, les responsabilités et les décisions ne s’alignent plus, Gersende de Parcey reconstruit la mécanique réelle d’une situation — puis rend cette reconstruction lisible, traçable et vérifiable.</p>
+          <p class="founder-kicker">GERSENDE DE PARCEY · FONDATRICE D’OPENPROOF · CRÉATRICE DE TRUTHX ENGINE</p>
+          <h1>RENDRE LE RÉEL DÉMONTRABLE.<span>AVANT, PENDANT ET APRÈS LA CRISE.</span></h1>
+          <p class="founder-hero-lead">Vingt ans de gouvernance, de transformation et de gestion de crise l’ont conduite à identifier une défaillance commune aux situations complexes : les sources, les obligations, les décisions, les responsabilités et les résultats sont dispersés entre trop d’acteurs et trop de systèmes. TruthX Engine transforme cette fragmentation en continuité vérifiable.</p>
+          <div class="founder-crossline" aria-label="Attendu, déclaré, décidé, prouvé et livré">
+            <span>ATTENDU</span><b>×</b><span>DÉCLARÉ</span><b>×</b><span>DÉCIDÉ</span><b>×</b><span>PROUVÉ</span><b>×</b><span>LIVRÉ</span>
+          </div>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-fr" data-contact-focus>Discuter d’une mission ou d’un partenariat</a>
-            <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
-            <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
+            <a class="btn primary" href="/fr/truthx-engine/">Découvrir TruthX Engine</a>
+            <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas</a>
+            <a class="founder-text-link" href="#rpo-contact-form-fr" data-contact-focus>Mission, recherche ou partenariat ↗</a>
           </div>
         </div>
 
         <figure class="founder-portrait-stage" data-reveal="right">
-          <div class="founder-portrait-card">
-            <img src="/images/gersende-de-parcey-full.svg" alt="Portrait de Gersende de Parcey" width="600" height="600" fetchpriority="high">
+          <div class="founder-portrait-frame">
+            <div class="founder-portrait-card">
+              <img src="/images/gersende-de-parcey-full.svg" alt="Portrait de Gersende de Parcey" width="600" height="760" fetchpriority="high">
+            </div>
+            <figcaption class="founder-portrait-label">
+              <span><strong>Gersende de Parcey</strong><span>Fondatrice d’OpenProof · Créatrice de TruthX Engine</span></span>
+              <b aria-hidden="true">01</b>
+            </figcaption>
           </div>
-          <div class="founder-portrait-stat founder-portrait-stat--top" aria-hidden="true">
-            <span>Expérience terrain</span>
-            <strong>20+ ans</strong>
-          </div>
-          <div class="founder-portrait-stat founder-portrait-stat--bottom" aria-hidden="true">
-            <span>Discipline</span>
-            <strong>Reality Engineering</strong>
-          </div>
-          <figcaption class="founder-portrait-label">
-            <span><strong>Gersende de Parcey</strong><span>Fondatrice d’OpenProof · Créatrice de TruthX Engine</span></span>
-            <b class="founder-portrait-mark" aria-hidden="true">01</b>
-          </figcaption>
         </figure>
 
-        <div class="founder-credibility" role="group" aria-label="Domaines d’expérience" data-reveal-group>
-          <span>20+ ans de terrain</span>
-          <span>Gouvernance</span>
-          <span>Décision</span>
-          <span>Transformation</span>
+        <div class="founder-credibility" role="group" aria-label="Repères professionnels" data-reveal-group>
+          <span>20+ ANS DE TERRAIN</span><span>GOUVERNANCE</span><span>TRANSFORMATION</span><span>INTÉGRITÉ DÉCISIONNELLE</span>
         </div>
       </div>
     </header>
 
-    <div class="founder-rail" aria-hidden="true">
-      <div class="founder-rail-track" aria-hidden="true">
-        <div class="founder-rail-group">
-          <span>Source</span><i></i><span>Provenance</span><i></i><span>Fait</span><i></i><span>Décision</span><i></i><span>Contradiction</span><i></i><span>Conséquence</span><i></i><span>Réserve</span><i></i><span>Responsabilité humaine</span><i></i>
+    <section class="founder-chapter founder-sight" aria-labelledby="sight-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>01 · CE QU’ELLE VOIT</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="sight-title" data-reveal="left">LES ORGANISATIONS NE MANQUENT PAS DE DONNÉES. ELLES MANQUENT D’UNE REPRÉSENTATION COMMUNE ET VÉRIFIABLE DU RÉEL.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">Gersende intervient lorsque plusieurs versions d’une même situation coexistent sans pouvoir être comparées proprement. Son travail consiste à rendre visibles les écarts entre structure officielle, pouvoir effectif, décisions, exécution et résultat.</p>
         </div>
-        <div class="founder-rail-group">
-          <span>Source</span><i></i><span>Provenance</span><i></i><span>Fait</span><i></i><span>Décision</span><i></i><span>Contradiction</span><i></i><span>Conséquence</span><i></i><span>Réserve</span><i></i><span>Responsabilité humaine</span><i></i>
-        </div>
-      </div>
-    </div>
-
-    <section class="founder-chapter founder-field">
-      <div class="wrap">
-        <div class="founder-intro-grid">
-          <div data-reveal="left">
-            <p class="founder-kicker">Son terrain</p>
-            <h2 class="founder-section-title">Rendre visible ce qui gouverne réellement la situation.</h2>
-          </div>
-          <p class="founder-section-lead" data-reveal="right">Elle intervient lorsque l’organisation décrite ne correspond plus à l’organisation réelle : informations fragmentées, responsabilités diffuses, décisions ralenties, récits contradictoires, coûts cachés ou rapports de force invisibles.</p>
-        </div>
-        <div class="founder-card-grid" data-reveal-group>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">01 · CRISE</span>
-            <h3>Crise ou conflit de récits</h3>
-            <p>Reconstituer les faits, la chronologie, les responsabilités et les contradictions.</p>
-          </article>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">02 · TRANSFORMATION</span>
-            <h3>Transformation devenue illisible</h3>
-            <p>Identifier ce qui bloque réellement la décision, l’exécution ou la performance.</p>
-          </article>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">03 · DÉCISION</span>
-            <h3>Décision critique</h3>
-            <p>Construire une représentation sourcée, explicite et défendable avant d’arbitrer.</p>
-          </article>
+        <div class="founder-signal-grid" data-reveal-group>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">01 · POUVOIR</span><h3>Organisation officielle / fonctionnement réel</h3><p>Distinguer les fonctions affichées des accès, dépendances, capacités d’action et pouvoirs de blocage effectivement observables.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">02 · INFORMATION</span><h3>Données disponibles / réalité partageable</h3><p>Relier les sources dispersées, leur provenance, leurs versions et leurs contradictions sans transformer leur simple présence en vérité.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">03 · DÉCISION</span><h3>Décision enregistrée / mécanique réelle</h3><p>Reconstituer qui a décidé, avec quelles informations, quels désaccords, quelles contraintes et quels risques acceptés.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">04 · EXÉCUTION</span><h3>Avancement déclaré / résultat démontré</h3><p>Comparer ce qui était attendu, annoncé, corrigé et finalement livré à partir de critères et de preuves explicitement conservés.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-origin">
-      <div class="wrap">
-        <div class="founder-origin-head">
-          <div data-reveal="left">
-            <p class="founder-kicker">L’origine</p>
-            <h2 class="founder-section-title">Deux fractures.<br>Une même mécanique.</h2>
-          </div>
-          <p class="founder-origin-thesis" data-reveal="right">L’origine compte parce qu’elle révèle une défaillance structurelle — non parce qu’elle définit celle qui l’a identifiée.</p>
+    <section class="founder-chapter founder-built" aria-labelledby="built-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>02 · CE QU’ELLE A CONSTRUIT</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="built-title" data-reveal="left">UN MOTEUR UNIVERSEL D’INTÉGRITÉ FACTUELLE, DÉCISIONNELLE ET PROBATOIRE.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">TruthX Engine ne décrète pas la vérité et ne remplace aucun professionnel habilité. Il organise les conditions permettant de savoir ce que les sources étayent, ce qui reste contesté, ce qui manque et si l’exécution demeure cohérente avec les obligations et décisions enregistrées.</p>
         </div>
-
-        <div class="founder-origin-map" data-reveal-group>
-          <article class="founder-origin-event">
-            <span class="founder-number">01 · RUPTURE INSTITUTIONNELLE</span>
-            <h3>Quand la protection peut retirer le pouvoir d’agir.</h3>
-            <p>Le décès de son mari, officier, révèle comment des procédures conçues au nom de la protection peuvent néanmoins priver un adulte responsable de sa capacité à décider et à protéger ses propres enfants.</p>
-          </article>
-          <div class="founder-origin-bridge" aria-hidden="true"><span>Même<br>mécanique</span></div>
-          <article class="founder-origin-event">
-            <span class="founder-number">02 · RUPTURE DE GOUVERNANCE</span>
-            <h3>Quand les preuves existent mais perdent leur force.</h3>
-            <p>Des années plus tard, une crise de gouvernance traversée par des récits contradictoires montre que conserver les preuves ne suffit pas. Il faut encore reconstruire leur chronologie, leur provenance, leurs relations et leurs contradictions.</p>
-          </article>
+        <div class="founder-integrity-grid" data-reveal-group>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">01 · FACTUELLE</span><h3>Intégrité factuelle</h3><p>Les affirmations, événements, contradictions et inconnues restent reliés à leurs sources et à leur niveau d’étayage.</p></article>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">02 · DÉCISIONNELLE</span><h3>Intégrité décisionnelle</h3><p>Les décisions conservent leur question, les informations disponibles, les options, les validations, les désaccords et les risques acceptés.</p></article>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">03 · PROBATOIRE</span><h3>Intégrité probatoire</h3><p>Les déclarations, actions, corrections et résultats restent démontrables, versionnés, contestables et auditables.</p></article>
         </div>
-
-        <p class="founder-origin-conclusion" data-reveal>Les faits peuvent exister et perdre la bataille faute de structure. <strong>Aucune personne ni aucune organisation ne devrait dépendre, sous pression, de sa seule mémoire pour reconstituer et expliquer ce qui s’est passé.</strong></p>
+        <blockquote class="founder-doctrine" data-reveal>TruthX ne gère pas le travail à la place des professionnels. Il garantit que ce qui est déclaré, décidé, modifié, corrigé et livré reste démontrable.</blockquote>
       </div>
     </section>
 
-    <section class="founder-chapter founder-method">
-      <div class="wrap founder-method-grid">
-        <div data-reveal="left">
-          <p class="founder-kicker">Vingt ans de terrain</p>
-          <h2 class="founder-section-title">Reconstruire le système réel.</h2>
+    <section class="founder-chapter founder-modes" aria-labelledby="modes-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>03 · DEUX MODES D’INTERVENTION</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="modes-title" data-reveal="left">UN SEUL MOTEUR. DEUX MOMENTS D’INTERVENTION.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">Le moment change, pas la discipline. TruthX peut reconstruire une situation après l’échec ou maintenir son intégrité pendant que l’action peut encore être corrigée.</p>
         </div>
-        <div class="founder-method-copy" data-reveal="right">
-          <p>Bien avant OpenProof, c’était déjà son métier : entrer dans des situations complexes, retrouver l’origine de l’information, identifier qui décide réellement et reconstituer les chaînes causales qui relient une décision à ses conséquences.</p>
-          <p>Elle appelle cette pratique <strong>Organizational Reality Engineering</strong> : rendre le fonctionnement réel d’une organisation suffisamment lisible pour être compris, contesté et transformé.</p>
-          <div class="founder-questions" data-reveal-group>
-            <div class="founder-question"><b>01</b><span>Qui décide réellement ?</span></div>
-            <div class="founder-question"><b>02</b><span>À partir de quelle source ?</span></div>
-            <div class="founder-question"><b>03</b><span>Par quel mécanisme ?</span></div>
-            <div class="founder-question"><b>04</b><span>Avec quelle conséquence ?</span></div>
-          </div>
+        <div class="founder-modes-grid" data-reveal-group>
+          <article class="founder-mode-card"><span class="founder-number">01 · APRÈS LES FAITS</span><h3>Reconstruction rétrospective</h3><p>Lorsque la crise, le conflit ou l’échec existe déjà, TruthX reconstitue le système réel sans réécrire l’histoire.</p><ul><li>Sources et chronologie</li><li>Pouvoirs formels et effectifs</li><li>Contradictions et lacunes</li><li>Hypothèses et causalités concurrentes</li><li>Base revue pour audit, médiation ou droit</li></ul></article>
+          <article class="founder-mode-card"><span class="founder-number">02 · PENDANT L’ACTION</span><h3>Intégrité continue</h3><p>Lorsque le projet est encore en mouvement, TruthX contrôle la continuité entre obligations, décisions, actions, corrections et preuves de livraison.</p><ul><li>Exigences, jalons et dépendances</li><li>Décisions, désaccords et risques acceptés</li><li>Avancement déclaré contre critères d’acceptation</li><li>Alertes et demandes de preuves</li><li>Instantanés RPO successifs</li></ul></article>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-shift">
-      <div class="wrap">
-        <div class="founder-shift-head">
-          <div data-reveal="left">
-            <p class="founder-kicker">Le basculement</p>
-            <h2 class="founder-section-title">L’IA a rendu la méthode reproductible. Pas infaillible.</h2>
-          </div>
-          <div class="founder-shift-copy" data-reveal="right">
-            <p>L’intelligence artificielle ne garantit pas la vérité. Elle rend possible la structuration, la mise en relation et l’examen de volumes d’information qu’une reconstruction manuelle ne peut soutenir avec la même profondeur.</p>
-            <p><strong>La technologie ne remplace pas le jugement humain. Elle lui donne mémoire, structure, provenance et traçabilité.</strong></p>
-          </div>
-        </div>
-
-        <div class="founder-system" data-reveal-group>
-          <article class="founder-system-card">
-            <span class="founder-system-role">01 · Le moteur</span>
-            <h3>TruthX Engine</h3>
-            <p>Relie sources, faits, décisions, acteurs, contradictions et conséquences selon des règles explicites.</p>
-          </article>
-          <article class="founder-system-card">
-            <span class="founder-system-role">02 · L’infrastructure</span>
-            <h3>OpenProof</h3>
-            <p>Rend inspectable, traçable, explicable et auditable la construction d’un raisonnement.</p>
-          </article>
-          <article class="founder-system-card">
-            <span class="founder-system-role">03 · L’objet</span>
-            <h3>RPO</h3>
-            <p>Conserve le dossier structuré, ses sources, ses transformations, ses réserves et ses données d’intégrité.</p>
-          </article>
+    <section class="founder-chapter founder-method" aria-labelledby="method-title">
+      <div class="founder-wrap founder-method-grid">
+        <div data-reveal="left"><p class="founder-kicker">04 · DU TERRAIN AU MOTEUR</p><h2 class="founder-section-title" id="method-title">ORGANIZATIONAL REALITY ENGINEERING.</h2><p class="founder-method-intro editorial">Bien avant OpenProof, c’était déjà sa pratique : entrer dans des environnements complexes, retrouver l’origine de l’information, identifier qui décide réellement et reconstruire les mécanismes reliant décisions, actions et conséquences. TruthX Engine formalise cette méthode humaine sans prétendre la remplacer.</p></div>
+        <div class="founder-question-grid" data-reveal-group>
+          <div class="founder-question"><b>01</b><span>Qui décide réellement ?</span></div><div class="founder-question"><b>02</b><span>À partir de quelle source ?</span></div><div class="founder-question"><b>03</b><span>Par quel mécanisme ?</span></div><div class="founder-question"><b>04</b><span>Avec quelle conséquence ?</span></div><div class="founder-question"><b>05</b><span>Qu’est-ce qui était attendu ?</span></div><div class="founder-question"><b>06</b><span>Qu’est-ce qui a été déclaré ?</span></div><div class="founder-question"><b>07</b><span>Qu’est-ce qui peut être démontré ?</span></div><div class="founder-question"><b>08</b><span>Qu’est-ce qui a finalement été livré ?</span></div>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-verification">
-      <div class="wrap">
-        <p class="founder-kicker" data-reveal>Ce qui est déjà vérifiable</p>
-        <h2 class="founder-section-title" data-reveal>Pas de boîte noire.<br>Trois points de vérification publics.</h2>
-
-        <div class="founder-proof-layout" data-reveal-group>
-          <a class="founder-proof-card founder-proof-card--research" data-spotlight href="https://dias.users.greyc.fr/about.html" target="_blank" rel="noopener noreferrer">
-            <span class="founder-proof-status">Source publique</span>
-            <h3>Origine scientifique</h3>
-            <p>Un prototype de recherche développé avec Gaël Dias, professeur en traitement automatique du langage à l’Université de Caen Normandie et co-directeur du GREYC (CNRS UMR 6072), a contribué à la genèse de TruthX Engine.</p>
-            <span class="founder-proof-cta">Voir le profil de recherche ↗</span>
-          </a>
-          <div class="founder-proof-stack">
-            <a class="founder-proof-card" data-spotlight href="/fr/">
-              <span class="founder-proof-status">Spécification ouverte</span>
-              <h3>RPO v0.1</h3>
-              <p>Le format public décrit sa structure, sa sérialisation canonique, ses réserves et le calcul de son empreinte SHA-256.</p>
-              <span class="founder-proof-cta">Explorer la spécification ↗</span>
-            </a>
-            <a class="founder-proof-card" data-spotlight href="/fr/tests.html">
-              <span class="founder-proof-status">Vérification locale</span>
-              <h3>Vérification indépendante</h3>
-              <p>L’empreinte peut être recalculée localement dans le navigateur, sans envoyer l’objet à OpenProof.</p>
-              <span class="founder-proof-cta">Vérifier un RPO ↗</span>
-            </a>
-          </div>
+    <section class="founder-chapter founder-origin" aria-labelledby="origin-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>05 · L’ORIGINE</p>
+        <div class="founder-origin-grid">
+          <div data-reveal="left"><h2 class="founder-section-title" id="origin-title">LES FAITS PEUVENT EXISTER ET PERDRE LEUR FORCE.</h2><blockquote>La vérité ne suffit pas. Elle doit pouvoir résister au pouvoir du récit.</blockquote></div>
+          <div class="founder-origin-copy" data-reveal="right"><p class="editorial">Deux ruptures — l’une institutionnelle, l’autre de gouvernance — ont révélé la même défaillance : des faits peuvent être réels, des preuves peuvent être conservées et des responsabilités peuvent exister sans rester intelligibles ni démontrables. La doctrine de TruthX est née de cette répétition structurelle, non d’une volonté de transformer une histoire personnelle en argument commercial.</p><div class="founder-origin-points"><div><span>01</span><strong>Rupture institutionnelle</strong><p>Comprendre que des procédures conçues pour protéger peuvent dissocier responsabilité, information et pouvoir réel d’agir.</p></div><div><span>02</span><strong>Rupture de gouvernance</strong><p>Comprendre que conserver des pièces ne suffit pas lorsque leur chronologie, leur provenance, leurs relations et leurs contradictions ne sont pas reconstruites.</p></div></div></div>
         </div>
       </div>
     </section>
 
-    <section class="founder-doctrine">
-      <div class="wrap" data-reveal>
-        <p class="founder-kicker">Conviction fondatrice</p>
-        <blockquote>Comprendre ne suffit pas. <span>Il faut pouvoir démontrer.</span></blockquote>
-        <p>OpenProof ne déclare pas ce qui est vrai. Il rend vérifiable la manière dont une représentation des faits a été construite : à partir de quelles sources, selon quelles règles, par quelles transformations, avec quelles contradictions, quelles incertitudes et sous quelle responsabilité.</p>
+    <section class="founder-chapter founder-architecture" aria-labelledby="architecture-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>06 · DE LA MÉTHODE À L’INFRASTRUCTURE</p><h2 class="founder-section-title" id="architecture-title" data-reveal>UNE PERSONNE CADRE. LE MOTEUR STRUCTURE. L’INFRASTRUCTURE REND VÉRIFIABLE.</h2>
+        <div class="founder-chain" data-reveal-group>
+          <article><span>LA MÉTHODE</span><h3>Gersende de Parcey</h3><p>Cadre la vraie question, lit le système réel, identifie les angles morts et protège la séparation entre conclusion et preuve.</p></article><b aria-hidden="true">→</b><article><span>LE MOTEUR</span><h3>TruthX Engine</h3><p>Structure et compare sources, attentes, décisions, actions, contradictions, causalités, responsabilités et résultats.</p></article><b aria-hidden="true">→</b><article><span>L’INFRASTRUCTURE</span><h3>OpenProof</h3><p>Conserve les transformations, les réserves, les revues humaines et les conditions de vérification.</p></article><b aria-hidden="true">→</b><article><span>L’OBJET</span><h3>RPO</h3><p>Enregistre une représentation versionnée, sourcée, revue et indépendamment vérifiable.</p></article>
+        </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-contact">
-      <div class="wrap founder-contact-grid">
-        <div data-reveal="left">
-          <p class="founder-kicker">Mission · Partenariat</p>
-          <h2 class="founder-section-title">Une situation critique mérite mieux qu’une opinion de plus.</h2>
-          <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-fr" data-contact-focus>Me contacter — mission ou partenariat</a>
-            <a class="btn" href="https://openproof.net">Découvrir OpenProof</a>
-            <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=Demande%20d%E2%80%99acc%C3%A8s%20pilote%20OpenProof">Demander un accès pilote ↗</a>
-          </div>
+    <section class="founder-chapter founder-axis" aria-labelledby="axis-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>07 · AXE INTERNATIONAL</p>
+        <div class="founder-heading-grid"><h2 class="founder-section-title" id="axis-title" data-reveal="left">PARIS × SYDNEY — DEUX ENVIRONNEMENTS INSTITUTIONNELS. UN MOTEUR CONÇU POUR RESTER UNIVERSEL.</h2><p class="founder-section-lead editorial" data-reveal="right">TruthX se développe depuis un ancrage institutionnel européen, avec un axe France–Australie en construction pour la recherche, les pilotes et le déploiement. Paris et Sydney ne sont pas des éléments de doctrine : ce sont deux terrains complémentaires permettant de tester l’universalité du moteur.</p></div>
+        <div class="founder-axis-grid" data-reveal-group><article><span class="founder-axis-city">PARIS</span><h3>Ancrage européen prioritaire</h3><p>Paris concentre droit civil, institutions européennes, recherche scientifique, grands groupes et transformations complexes.</p><ul><li>Gouvernance et décision institutionnelle</li><li>Droit civil et régulation européenne</li><li>Recherche et partenariats scientifiques</li><li>Marché prioritaire pour missions et pilotes</li></ul></article><div class="founder-axis-x" aria-hidden="true">×</div><article><span class="founder-axis-city">SYDNEY</span><h3>Axe APAC en développement</h3><p>Sydney relie common law, infrastructures, assurance de livraison, investigation et accès à l’Asie-Pacifique.</p><ul><li>Grands projets et delivery assurance</li><li>Common law, assurance et eDiscovery</li><li>Recherche et pilotes France–Australie</li><li>Porte d’entrée vers l’écosystème APAC</li></ul></article></div>
+        <p class="founder-axis-note">Cet axe décrit une stratégie de recherche et de déploiement. Il ne constitue pas l’annonce de deux bureaux déjà établis.</p>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-verification" aria-labelledby="verification-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>08 · CE QUI EST DÉJÀ VÉRIFIABLE</p><div class="founder-heading-grid"><h2 class="founder-section-title" id="verification-title" data-reveal="left">PAS DE BOÎTE NOIRE. DES POINTS PUBLICS DE CONTRÔLE.</h2><p class="founder-section-lead editorial" data-reveal="right">La crédibilité ne repose pas seulement sur une promesse. Une partie de la filiation scientifique, de la doctrine, du format de sortie et de la vérification est déjà accessible publiquement.</p></div>
+        <div class="founder-proof-grid" data-reveal-group>
+          <a class="founder-proof-card" data-spotlight href="https://dias.users.greyc.fr/about.html" target="_blank" rel="noopener noreferrer"><span class="founder-proof-status">SOURCE PUBLIQUE</span><h3>Filiation de recherche GREYC / CNRS</h3><p>Une collaboration de recherche en traitement automatique du langage a contribué à la genèse de TruthX Engine.</p><span class="founder-proof-cta">Voir le profil de recherche ↗</span></a>
+          <a class="founder-proof-card" data-spotlight href="/fr/truthx-engine/"><span class="founder-proof-status">DOCTRINE PUBLIQUE</span><h3>TruthX Engine</h3><p>La doctrine publique expose le moteur d’intégrité factuelle, décisionnelle et probatoire sans révéler son implémentation privée.</p><span class="founder-proof-cta">Lire la doctrine →</span></a>
+          <a class="founder-proof-card" data-spotlight href="/fr/"><span class="founder-proof-status">SPÉCIFICATION OUVERTE</span><h3>RPO v0.1</h3><p>Le format public définit structure, sérialisation canonique, réserves et empreinte SHA-256.</p><span class="founder-proof-cta">Explorer la spécification →</span></a>
+          <a class="founder-proof-card" data-spotlight href="/fr/tests.html"><span class="founder-proof-status">VÉRIFICATION LOCALE</span><h3>Contrôle indépendant</h3><p>L’empreinte d’un RPO peut être recalculée localement dans le navigateur, sans transmission à OpenProof.</p><span class="founder-proof-cta">Vérifier un RPO →</span></a>
         </div>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-now" aria-labelledby="now-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>09 · CE QU’ELLE CONSTRUIT MAINTENANT</p><div class="founder-heading-grid"><h2 class="founder-section-title" id="now-title" data-reveal="left">CHAQUE PROJET COMPLEXE DEVRAIT PRODUIRE, AU FIL DE SON EXÉCUTION, SON PROPRE DOSSIER VÉRIFIABLE.</h2><p class="founder-section-lead editorial" data-reveal="right">Le droit constitue la première verticale démontrable. La même architecture peut ensuite soutenir la livraison de grands projets, les défauts et remédiations, l’assurance, la gouvernance, les enquêtes et les transformations critiques.</p></div>
+        <div class="founder-now-grid" data-reveal-group><article class="founder-now-card" data-spotlight><span class="founder-number">01 · DROIT</span><h3>Legal Evidence Lab</h3><p>Transformer une matière fragmentée en base factuelle et probatoire exploitable par les professionnels du droit.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">02 · LIVRAISON</span><h3>Project Delivery Integrity</h3><p>Relier exigences, jalons, décisions, corrections et preuves afin de rendre les dérives visibles avant l’échec.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">03 · DÉFAUTS</span><h3>Defect &amp; Remediation Intelligence</h3><p>Tracer défauts, notifications, inspections, responsabilités, remédiations promises et vérification des corrections.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">04 · EXTENSIONS</span><h3>Audit, assurance et gouvernance</h3><p>Utiliser le même noyau pour comprendre, arbitrer, assurer, auditer ou défendre des situations à forts enjeux.</p></article></div>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-contact" aria-labelledby="contact-title">
+      <div class="founder-wrap founder-contact-grid">
+        <div data-reveal="left"><p class="founder-kicker">10 · PILOTE · MISSION · PARTENARIAT</p><h2 class="founder-section-title" id="contact-title">QU’EST-CE QUI DOIT RESTER DÉMONTRABLE ?</h2><p class="founder-contact-copy editorial">Pour un cas réel, le parcours de qualification OpenProof permet de décrire le besoin sans transmettre de preuves confidentielles. Pour une mission d’Executive Advisor, une recherche, une intégration ou un partenariat, utilisez le formulaire ci-contre.</p><div class="founder-actions"><a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas</a><a class="btn" href="/fr/truthx-engine/">Découvrir TruthX Engine</a></div></div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p class="founder-contact-copy">Gersende de Parcey intervient aux côtés de dirigeants lorsque les faits doivent être reconstruits, les responsabilités clarifiées et la décision rendue plus robuste. Elle échange également avec les partenaires scientifiques, institutionnels et technologiques capables de tester, renforcer ou déployer OpenProof.</p>
-          <div class="founder-signal-head">
-            <p class="founder-form-kicker">TRUTHX SIGNAL</p>
-            <h3>RESTEZ CONNECTÉ AU SYSTÈME.</h3>
-            <p class="founder-contact-intro">Décrivez brièvement votre situation, votre mission ou votre proposition de partenariat. Gersende de Parcey vous répondra directement.</p>
-          </div>
-          <form id="rpo-contact-form-fr" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="fr" data-hubspot-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-page-name="Gersende de Parcey — Fondatrice OpenProof" data-submit-label="SOUMETTRE" data-sending-label="ENVOI…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
-            <label>Prénom<input type="text" name="firstname" autocomplete="given-name" required></label>
-            <label>Nom de famille<input type="text" name="lastname" autocomplete="family-name" required></label>
-            <label>Courriel professionnel<input type="email" name="email" autocomplete="email" required></label>
-            <label>Organisation (facultatif)<input type="text" name="company" autocomplete="organization"></label>
-            <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
-            <label class="founder-form-consent">
-              <input type="checkbox" name="processingConsent" required>
-              <span><b>Traitement des demandes</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span>
-            </label>
-            <label class="founder-form-consent">
-              <input type="checkbox" name="marketingConsent">
-              <span><b>Publications TruthX</b><small>Je souhaite recevoir les synthèses et invitations de TruthX. Je peux me désabonner à tout moment.</small></span>
-            </label>
-            <button class="founder-form-submit" type="submit"><span data-submit-text>SOUMETTRE</span><span aria-hidden="true">→</span></button>
-            <small class="founder-form-error" role="alert" aria-live="polite"></small>
-            <small class="founder-form-note">Vos données servent uniquement à traiter votre demande et, avec votre accord, à vous adresser les publications TruthX.</small>
+          <div class="founder-signal-head"><p class="founder-form-kicker">RECHERCHE · PARTENARIAT · INTÉGRATION</p><h3>CONSTRUIRE, TESTER OU DÉPLOYER L’INFRASTRUCTURE.</h3><p class="founder-contact-intro">Décrivez brièvement votre mission, votre proposition de recherche, d’intégration ou de partenariat. Gersende de Parcey vous répondra directement.</p></div>
+          <form id="rpo-contact-form-fr" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="fr" data-hubspot-form-id="4ba9cae0-6ec7-4685-9b52-b9f51866f505" data-page-name="Gersende de Parcey — Fondatrice OpenProof et créatrice de TruthX Engine" data-submit-label="SOUMETTRE" data-sending-label="ENVOI…" data-error-label="L’envoi n’a pas abouti. Réessayez ou écrivez directement à openproof@truthx.co.">
+            <label>Prénom<input type="text" name="firstname" autocomplete="given-name" required></label><label>Nom de famille<input type="text" name="lastname" autocomplete="family-name" required></label><label>Courriel professionnel<input type="email" name="email" autocomplete="email" required></label><label>Organisation (facultatif)<input type="text" name="company" autocomplete="organization"></label><label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
+            <label class="founder-form-consent"><input type="checkbox" name="processingConsent" required><span><b>Traitement des demandes</b><small>J’accepte que TruthX et OpenProof stockent et traitent mes données afin de répondre à ma demande.</small></span></label><label class="founder-form-consent"><input type="checkbox" name="marketingConsent"><span><b>Publications TruthX</b><small>Je souhaite recevoir les synthèses et invitations de TruthX. Je peux me désabonner à tout moment.</small></span></label>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>SOUMETTRE</span><span aria-hidden="true">→</span></button><small class="founder-form-error" role="alert" aria-live="polite"></small><small class="founder-form-note">Vos données servent uniquement à traiter votre demande et, avec votre accord, à vous adresser les publications TruthX.</small>
           </form>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a>
-          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
-            <strong>DEMANDE ENREGISTRÉE.</strong>
-            <p>Votre demande a bien été transmise. Vous serez recontacté directement.</p>
-          </div>
-          <noscript><p class="founder-form-noscript">Pour transmettre votre demande, écrivez à <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Écrire directement · openproof@truthx.co</a><div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden><strong>DEMANDE ENREGISTRÉE.</strong><p>Votre demande a bien été transmise. Vous serez recontacté directement.</p></div><noscript><p class="founder-form-noscript">Pour transmettre votre demande, écrivez à <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
   </main>
 
-  <footer class="footer rpo-footer">
-    <div class="wrap">
-      <div><strong>OPENPROOF</strong><p>Infrastructure probatoire pour les décisions critiques.</p></div>
-      <div class="footer-links">
-        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey sur LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
-        <a href="mailto:openproof@truthx.co">Contact</a>
-        <a href="/fr/">RPO</a>
-        <a href="https://openproof.net">OpenProof</a>
-      </div>
-    </div>
-  </footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260802-2"></script>
+  <footer class="footer rpo-footer"><div class="wrap"><div><strong>OPENPROOF</strong><p>Infrastructure probatoire pour les décisions et projets critiques.</p></div><div class="footer-links"><a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey sur LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a><a href="mailto:openproof@truthx.co">Contact</a><a href="/fr/truthx-engine/">TruthX Engine</a><a href="/fr/">RPO</a><a href="https://openproof.net">OpenProof</a></div></div></footer>
+  <script src="/assets/openproof-v2.js?v=20260805-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260805-1"></script>
 </body>
 </html>

--- a/docs/gersende-de-parcey.html
+++ b/docs/gersende-de-parcey.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050709">
-  <title>Gersende de Parcey | Executive Advisor &amp; Founder of OpenProof</title>
-  <meta name="description" content="Gersende de Parcey reconstructs the real mechanics of critical situations and makes facts, accountability and decisions legible, traceable and verifiable.">
+  <title>Gersende de Parcey | Founder of OpenProof & Creator of TruthX Engine</title>
+  <meta name="description" content="Gersende de Parcey, founder of OpenProof and creator of TruthX Engine, designs factual, decision and probative integrity systems for complex situations.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/gersende-de-parcey.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html">
@@ -14,40 +14,41 @@
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preload" as="image" href="/images/gersende-de-parcey-full.svg">
   <meta property="og:type" content="profile">
-  <meta property="og:title" content="Gersende de Parcey | Executive Advisor &amp; Founder of OpenProof">
-  <meta property="og:description" content="Reconstructing the real mechanics of critical situations — then making that reconstruction legible, traceable and verifiable.">
+  <meta property="og:title" content="Gersende de Parcey | Founder of OpenProof & Creator of TruthX Engine">
+  <meta property="og:description" content="Making reality demonstrable — before, during and after crisis.">
   <meta property="og:url" content="https://rpo.openproof.net/gersende-de-parcey.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/gersende-de-parcey.png?v=20260731-1">
   <meta property="og:locale" content="en_US">
   <meta property="og:locale:alternate" content="fr_FR">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Gersende de Parcey | Executive Advisor &amp; Founder of OpenProof">
-  <meta name="twitter:description" content="Reconstructing the real mechanics of critical situations — then making that reconstruction legible, traceable and verifiable.">
+  <meta name="twitter:title" content="Gersende de Parcey | Founder of OpenProof & Creator of TruthX Engine">
+  <meta name="twitter:description" content="Making reality demonstrable — before, during and after crisis.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/gersende-de-parcey.png?v=20260731-1">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260802-3">
+  <link rel="stylesheet" href="/assets/founder-reputation.css?v=20260805-4">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Gersende de Parcey",
     "url": "https://rpo.openproof.net/gersende-de-parcey.html",
-    "jobTitle": "Executive Advisor, Founder of OpenProof and Creator of TruthX Engine",
-    "sameAs": [
-      "https://www.linkedin.com/in/gryard/"
-    ],
+    "jobTitle": "Founder of OpenProof, creator of TruthX Engine and Executive Advisor",
+    "sameAs": ["https://www.linkedin.com/in/gryard/"],
     "image": "https://rpo.openproof.net/images/gersende-de-parcey-full.svg",
-    "description": "Executive advisor, founder of OpenProof and creator of TruthX Engine, extending a twenty-year methodology for reconstructing organizational reality into deterministic, probative infrastructure.",
+    "description": "Founder of OpenProof and creator of TruthX Engine, a universal factual, decision and probative integrity engine developed from twenty years of governance, transformation and crisis work.",
     "knowsAbout": [
+      "factual integrity",
+      "decision integrity",
+      "probative integrity",
       "Organizational Reality Engineering",
-      "probative infrastructure",
+      "governance",
       "decision reconstruction",
       "evidence provenance",
-      "governance",
-      "Registered Probative Object"
+      "Registered Probative Object",
+      "France-Australia research and deployment"
     ],
     "worksFor": {
       "@type": "Organization",
@@ -82,264 +83,161 @@
   </nav>
 
   <main id="main">
-    <header class="founder-hero cosmos">
+    <header class="founder-hero cosmos" id="overview">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap founder-hero-inner">
+      <div class="founder-hero-inner">
         <div class="founder-hero-copy" data-reveal="left">
-          <p class="founder-kicker">Gersende de Parcey · Executive Advisor · Founder of OpenProof</p>
-          <h1>Truth is not enough.<span>It must withstand the power of narrative.</span></h1>
-          <p class="founder-hero-lead">When facts, accountability and decisions no longer align, Gersende de Parcey reconstructs the real mechanics of a situation — then makes that reconstruction legible, traceable and verifiable.</p>
+          <p class="founder-kicker">GERSENDE DE PARCEY · FOUNDER OF OPENPROOF · CREATOR OF TRUTHX ENGINE</p>
+          <h1>MAKE REALITY DEMONSTRABLE.<span>BEFORE, DURING AND AFTER CRISIS.</span></h1>
+          <p class="founder-hero-lead">Twenty years in governance, transformation and crisis work led her to identify a failure shared by complex situations: sources, obligations, decisions, responsibilities and outcomes are fragmented across too many actors and too many systems. TruthX Engine turns that fragmentation into verifiable continuity.</p>
+          <div class="founder-crossline" aria-label="Expected, declared, decided, evidenced and delivered">
+            <span>EXPECTED</span><b>×</b><span>DECLARED</span><b>×</b><span>DECIDED</span><b>×</b><span>EVIDENCED</span><b>×</b><span>DELIVERED</span>
+          </div>
           <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-en" data-contact-focus>Discuss a mission or partnership</a>
-            <a class="btn" href="https://openproof.net">Discover OpenProof</a>
-            <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
+            <a class="btn primary" href="/truthx-engine/">Discover TruthX Engine</a>
+            <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualify a case</a>
+            <a class="founder-text-link" href="#rpo-contact-form-en" data-contact-focus>Mission, research or partnership ↗</a>
           </div>
         </div>
 
         <figure class="founder-portrait-stage" data-reveal="right">
-          <div class="founder-portrait-card">
-            <img src="/images/gersende-de-parcey-full.svg" alt="Portrait of Gersende de Parcey" width="600" height="600" fetchpriority="high">
+          <div class="founder-portrait-frame">
+            <div class="founder-portrait-card">
+              <img src="/images/gersende-de-parcey-full.svg" alt="Portrait of Gersende de Parcey" width="600" height="760" fetchpriority="high">
+            </div>
+            <figcaption class="founder-portrait-label">
+              <span><strong>Gersende de Parcey</strong><span>Founder of OpenProof · Creator of TruthX Engine</span></span>
+              <b aria-hidden="true">01</b>
+            </figcaption>
           </div>
-          <div class="founder-portrait-stat founder-portrait-stat--top" aria-hidden="true">
-            <span>Field experience</span>
-            <strong>20+ years</strong>
-          </div>
-          <div class="founder-portrait-stat founder-portrait-stat--bottom" aria-hidden="true">
-            <span>Discipline</span>
-            <strong>Reality Engineering</strong>
-          </div>
-          <figcaption class="founder-portrait-label">
-            <span><strong>Gersende de Parcey</strong><span>Founder of OpenProof · Creator of TruthX Engine</span></span>
-            <b class="founder-portrait-mark" aria-hidden="true">01</b>
-          </figcaption>
         </figure>
 
-        <div class="founder-credibility" role="group" aria-label="Areas of experience" data-reveal-group>
-          <span>20+ years in the field</span>
-          <span>Governance</span>
-          <span>Decision-making</span>
-          <span>Transformation</span>
+        <div class="founder-credibility" role="group" aria-label="Professional reference points" data-reveal-group>
+          <span>20+ YEARS IN THE FIELD</span><span>GOVERNANCE</span><span>TRANSFORMATION</span><span>DECISION INTEGRITY</span>
         </div>
       </div>
     </header>
 
-    <div class="founder-rail" aria-hidden="true">
-      <div class="founder-rail-track" aria-hidden="true">
-        <div class="founder-rail-group">
-          <span>Source</span><i></i><span>Provenance</span><i></i><span>Fact</span><i></i><span>Decision</span><i></i><span>Contradiction</span><i></i><span>Consequence</span><i></i><span>Reservation</span><i></i><span>Human accountability</span><i></i>
+    <section class="founder-chapter founder-sight" aria-labelledby="sight-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>01 · WHAT SHE SEES</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="sight-title" data-reveal="left">ORGANISATIONS DO NOT LACK DATA. THEY LACK A COMMON, VERIFIABLE REPRESENTATION OF REALITY.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">Gersende steps in when several versions of the same situation coexist without being properly comparable. Her work makes visible the gaps between formal structure, effective power, decisions, execution and outcome.</p>
         </div>
-        <div class="founder-rail-group">
-          <span>Source</span><i></i><span>Provenance</span><i></i><span>Fact</span><i></i><span>Decision</span><i></i><span>Contradiction</span><i></i><span>Consequence</span><i></i><span>Reservation</span><i></i><span>Human accountability</span><i></i>
-        </div>
-      </div>
-    </div>
-
-    <section class="founder-chapter founder-field">
-      <div class="wrap">
-        <div class="founder-intro-grid">
-          <div data-reveal="left">
-            <p class="founder-kicker">Her field</p>
-            <h2 class="founder-section-title">Make visible what is actually governing the situation.</h2>
-          </div>
-          <p class="founder-section-lead" data-reveal="right">She steps in when the organisation as described no longer matches the organisation as it actually operates: fragmented information, blurred accountability, slowed decisions, competing narratives, hidden costs or invisible power dynamics.</p>
-        </div>
-        <div class="founder-card-grid" data-reveal-group>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">01 · CRISIS</span>
-            <h3>Crisis or competing narratives</h3>
-            <p>Reconstruct the facts, chronology, accountability and contradictions.</p>
-          </article>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">02 · TRANSFORMATION</span>
-            <h3>An unreadable transformation</h3>
-            <p>Identify what is really blocking decision-making, execution or performance.</p>
-          </article>
-          <article class="founder-card" data-spotlight>
-            <span class="founder-number">03 · DECISION</span>
-            <h3>A critical decision</h3>
-            <p>Build a sourced, explicit and defensible representation before deciding.</p>
-          </article>
+        <div class="founder-signal-grid" data-reveal-group>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">01 · POWER</span><h3>Formal organisation / actual operation</h3><p>Separate displayed roles from the access, dependencies, capacity to act and blocking power that can actually be observed.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">02 · INFORMATION</span><h3>Available data / shareable reality</h3><p>Connect fragmented sources, provenance, versions and contradictions without turning their mere presence into truth.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">03 · DECISION</span><h3>Recorded decision / real mechanism</h3><p>Reconstruct who decided, with which information, disagreements, constraints and accepted risks.</p></article>
+          <article class="founder-signal-card" data-spotlight><span class="founder-number">04 · EXECUTION</span><h3>Declared progress / demonstrated outcome</h3><p>Compare what was expected, announced, corrected and ultimately delivered against explicit criteria and preserved evidence.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-origin">
-      <div class="wrap">
-        <div class="founder-origin-head">
-          <div data-reveal="left">
-            <p class="founder-kicker">The origin</p>
-            <h2 class="founder-section-title">Two ruptures.<br>The same mechanism.</h2>
-          </div>
-          <p class="founder-origin-thesis" data-reveal="right">The origin matters because it revealed a structural failure — not because it defines the person who identified it.</p>
+    <section class="founder-chapter founder-built" aria-labelledby="built-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>02 · WHAT SHE BUILT</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="built-title" data-reveal="left">A UNIVERSAL FACTUAL, DECISION AND PROBATIVE INTEGRITY ENGINE.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">TruthX Engine does not declare truth and does not replace any authorised professional. It organises the conditions required to determine what the sources support, what remains contested, what is missing and whether execution remains consistent with recorded obligations and decisions.</p>
         </div>
-
-        <div class="founder-origin-map" data-reveal-group>
-          <article class="founder-origin-event">
-            <span class="founder-number">01 · INSTITUTIONAL RUPTURE</span>
-            <h3>When protection can remove the power to act.</h3>
-            <p>The death of her husband, an army officer, exposed how procedures designed in the name of protection can nonetheless deprive a responsible adult of the ability to decide and protect her own children.</p>
-          </article>
-          <div class="founder-origin-bridge" aria-hidden="true"><span>Same<br>mechanism</span></div>
-          <article class="founder-origin-event">
-            <span class="founder-number">02 · GOVERNANCE RUPTURE</span>
-            <h3>When evidence exists but loses its force.</h3>
-            <p>Years later, a governance crisis shaped by competing narratives showed that preserved evidence was not enough. Its chronology, provenance, relationships and contradictions still had to be reconstructed.</p>
-          </article>
+        <div class="founder-integrity-grid" data-reveal-group>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">01 · FACTUAL</span><h3>Factual integrity</h3><p>Assertions, events, contradictions and unknowns remain connected to their sources and degree of support.</p></article>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">02 · DECISION</span><h3>Decision integrity</h3><p>Decisions preserve their question, available information, options, validations, disagreements and accepted risks.</p></article>
+          <article class="founder-integrity-card" data-spotlight><span class="founder-number">03 · PROBATIVE</span><h3>Probative integrity</h3><p>Declarations, actions, corrections and outcomes remain demonstrable, versioned, contestable and auditable.</p></article>
         </div>
-
-        <p class="founder-origin-conclusion" data-reveal>Facts can exist and still lose the battle when they lack structure. <strong>No person or organisation should have to rely, under pressure, on memory alone to reconstruct and explain what happened.</strong></p>
+        <blockquote class="founder-doctrine" data-reveal>TruthX does not manage the work on behalf of professionals. It ensures that what is declared, decided, changed, corrected and delivered remains demonstrable.</blockquote>
       </div>
     </section>
 
-    <section class="founder-chapter founder-method">
-      <div class="wrap founder-method-grid">
-        <div data-reveal="left">
-          <p class="founder-kicker">Twenty years in the field</p>
-          <h2 class="founder-section-title">Reconstructing the real system.</h2>
+    <section class="founder-chapter founder-modes" aria-labelledby="modes-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>03 · TWO OPERATING MODES</p>
+        <div class="founder-heading-grid">
+          <h2 class="founder-section-title" id="modes-title" data-reveal="left">ONE ENGINE. TWO MOMENTS OF INTERVENTION.</h2>
+          <p class="founder-section-lead editorial" data-reveal="right">The moment changes, not the discipline. TruthX can reconstruct a situation after failure or maintain its integrity while action can still be corrected.</p>
         </div>
-        <div class="founder-method-copy" data-reveal="right">
-          <p>Long before OpenProof, this was already her work: entering complex situations, tracing information back to its source, identifying who actually decides, and rebuilding the causal chains between decisions and consequences.</p>
-          <p>She calls this practice <strong>Organizational Reality Engineering</strong>: making an organisation’s actual operation legible enough to be understood, challenged and transformed.</p>
-          <div class="founder-questions" data-reveal-group>
-            <div class="founder-question"><b>01</b><span>Who actually decides?</span></div>
-            <div class="founder-question"><b>02</b><span>From which source?</span></div>
-            <div class="founder-question"><b>03</b><span>Through which mechanism?</span></div>
-            <div class="founder-question"><b>04</b><span>With what consequence?</span></div>
-          </div>
+        <div class="founder-modes-grid" data-reveal-group>
+          <article class="founder-mode-card"><span class="founder-number">01 · AFTER THE EVENT</span><h3>Retrospective reconstruction</h3><p>When the crisis, dispute or failure already exists, TruthX reconstructs the real system without rewriting history.</p><ul><li>Sources and chronology</li><li>Formal and effective power</li><li>Contradictions and gaps</li><li>Competing hypotheses and causalities</li><li>Reviewed basis for audit, mediation or legal work</li></ul></article>
+          <article class="founder-mode-card"><span class="founder-number">02 · DURING EXECUTION</span><h3>Continuous integrity</h3><p>While a project is still in motion, TruthX controls continuity across obligations, decisions, actions, corrections and delivery evidence.</p><ul><li>Requirements, milestones and dependencies</li><li>Decisions, disagreements and accepted risks</li><li>Declared progress against acceptance criteria</li><li>Alerts and evidence requests</li><li>Successive RPO snapshots</li></ul></article>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-shift">
-      <div class="wrap">
-        <div class="founder-shift-head">
-          <div data-reveal="left">
-            <p class="founder-kicker">The shift</p>
-            <h2 class="founder-section-title">AI made the method reproducible. Not infallible.</h2>
-          </div>
-          <div class="founder-shift-copy" data-reveal="right">
-            <p>Artificial intelligence does not guarantee truth. It makes it possible to structure, connect and examine volumes of information that manual reconstruction cannot sustain at the same depth.</p>
-            <p><strong>Technology does not replace human judgment. It gives judgment memory, structure, provenance and traceability.</strong></p>
-          </div>
-        </div>
-
-        <div class="founder-system" data-reveal-group>
-          <article class="founder-system-card">
-            <span class="founder-system-role">01 · The engine</span>
-            <h3>TruthX Engine</h3>
-            <p>Connects sources, facts, decisions, actors, contradictions and consequences under explicit rules.</p>
-          </article>
-          <article class="founder-system-card">
-            <span class="founder-system-role">02 · The infrastructure</span>
-            <h3>OpenProof</h3>
-            <p>Makes the construction of reasoning inspectable, traceable, explainable and auditable.</p>
-          </article>
-          <article class="founder-system-card">
-            <span class="founder-system-role">03 · The object</span>
-            <h3>RPO</h3>
-            <p>Preserves the structured record, its sources, transformations, reservations and integrity data.</p>
-          </article>
+    <section class="founder-chapter founder-method" aria-labelledby="method-title">
+      <div class="founder-wrap founder-method-grid">
+        <div data-reveal="left"><p class="founder-kicker">04 · FROM FIELDWORK TO ENGINE</p><h2 class="founder-section-title" id="method-title">ORGANIZATIONAL REALITY ENGINEERING.</h2><p class="founder-method-intro editorial">Long before OpenProof, this was already her practice: entering complex environments, tracing information back to its source, identifying who actually decides and reconstructing the mechanisms linking decisions, actions and consequences. TruthX Engine formalises that human method without claiming to replace it.</p></div>
+        <div class="founder-question-grid" data-reveal-group>
+          <div class="founder-question"><b>01</b><span>Who actually decides?</span></div><div class="founder-question"><b>02</b><span>From which source?</span></div><div class="founder-question"><b>03</b><span>Through which mechanism?</span></div><div class="founder-question"><b>04</b><span>With what consequence?</span></div><div class="founder-question"><b>05</b><span>What was expected?</span></div><div class="founder-question"><b>06</b><span>What was declared?</span></div><div class="founder-question"><b>07</b><span>What can be demonstrated?</span></div><div class="founder-question"><b>08</b><span>What was ultimately delivered?</span></div>
         </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-verification">
-      <div class="wrap">
-        <p class="founder-kicker" data-reveal>What is already verifiable</p>
-        <h2 class="founder-section-title" data-reveal>No black box.<br>Three public points of verification.</h2>
-
-        <div class="founder-proof-layout" data-reveal-group>
-          <a class="founder-proof-card founder-proof-card--research" data-spotlight href="https://dias.users.greyc.fr/about.html" target="_blank" rel="noopener noreferrer">
-            <span class="founder-proof-status">Public source</span>
-            <h3>Research lineage</h3>
-            <p>A research prototype developed with Gaël Dias, Full Professor in Natural Language Processing at the University of Caen Normandy and co-Director of GREYC (CNRS UMR 6072), contributed to the genesis of TruthX Engine.</p>
-            <span class="founder-proof-cta">View research profile ↗</span>
-          </a>
-          <div class="founder-proof-stack">
-            <a class="founder-proof-card" data-spotlight href="/">
-              <span class="founder-proof-status">Open specification</span>
-              <h3>RPO v0.1</h3>
-              <p>The public format defines its structure, canonical serialisation, reservations and SHA-256 fingerprint computation.</p>
-              <span class="founder-proof-cta">Explore the specification ↗</span>
-            </a>
-            <a class="founder-proof-card" data-spotlight href="/tests.html">
-              <span class="founder-proof-status">Local verification</span>
-              <h3>Independent verification</h3>
-              <p>The fingerprint can be recomputed locally in the browser, without sending the object to OpenProof.</p>
-              <span class="founder-proof-cta">Verify an RPO ↗</span>
-            </a>
-          </div>
+    <section class="founder-chapter founder-origin" aria-labelledby="origin-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>05 · THE ORIGIN</p>
+        <div class="founder-origin-grid">
+          <div data-reveal="left"><h2 class="founder-section-title" id="origin-title">FACTS CAN EXIST AND STILL LOSE THEIR FORCE.</h2><blockquote>Truth is not enough. It must withstand the power of narrative.</blockquote></div>
+          <div class="founder-origin-copy" data-reveal="right"><p class="editorial">Two ruptures — one institutional, one in governance — revealed the same failure: facts can be real, evidence can be preserved and responsibilities can exist without remaining intelligible or demonstrable. The TruthX doctrine emerged from this structural repetition, not from a desire to turn a personal history into a commercial argument.</p><div class="founder-origin-points"><div><span>01</span><strong>Institutional rupture</strong><p>Understanding that procedures designed to protect can separate responsibility, information and the actual power to act.</p></div><div><span>02</span><strong>Governance rupture</strong><p>Understanding that preserving documents is not enough when their chronology, provenance, relationships and contradictions have not been reconstructed.</p></div></div></div>
         </div>
       </div>
     </section>
 
-    <section class="founder-doctrine">
-      <div class="wrap" data-reveal>
-        <p class="founder-kicker">Founding conviction</p>
-        <blockquote>Understanding is not enough. <span>It must be demonstrable.</span></blockquote>
-        <p>OpenProof does not declare what is true. It makes verifiable how a representation of facts was constructed: from which sources, under which rules, through which transformations, with which contradictions and uncertainties, and under whose responsibility.</p>
+    <section class="founder-chapter founder-architecture" aria-labelledby="architecture-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>06 · FROM METHOD TO INFRASTRUCTURE</p><h2 class="founder-section-title" id="architecture-title" data-reveal>A PERSON FRAMES. THE ENGINE STRUCTURES. THE INFRASTRUCTURE MAKES IT VERIFIABLE.</h2>
+        <div class="founder-chain" data-reveal-group>
+          <article><span>THE METHOD</span><h3>Gersende de Parcey</h3><p>Frames the real question, reads the actual system, identifies blind spots and protects the separation between conclusion and evidence.</p></article><b aria-hidden="true">→</b><article><span>THE ENGINE</span><h3>TruthX Engine</h3><p>Structures and compares sources, expectations, decisions, actions, contradictions, causalities, responsibilities and outcomes.</p></article><b aria-hidden="true">→</b><article><span>THE INFRASTRUCTURE</span><h3>OpenProof</h3><p>Preserves transformations, reservations, human reviews and the conditions for verification.</p></article><b aria-hidden="true">→</b><article><span>THE OBJECT</span><h3>RPO</h3><p>Records a versioned, sourced, reviewed and independently verifiable representation.</p></article>
+        </div>
       </div>
     </section>
 
-    <section class="founder-chapter founder-contact">
-      <div class="wrap founder-contact-grid">
-        <div data-reveal="left">
-          <p class="founder-kicker">Mission · Partnership</p>
-          <h2 class="founder-section-title">A critical situation deserves more than another opinion.</h2>
-          <div class="founder-actions">
-            <a class="btn primary" href="#rpo-contact-form-en" data-contact-focus>Contact me — mission or partnership</a>
-            <a class="btn" href="https://openproof.net">Discover OpenProof</a>
-            <a class="founder-text-link" href="mailto:openproof@truthx.co?subject=OpenProof%20pilot%20access%20request">Request pilot access ↗</a>
-          </div>
+    <section class="founder-chapter founder-axis" aria-labelledby="axis-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>07 · INTERNATIONAL AXIS</p>
+        <div class="founder-heading-grid"><h2 class="founder-section-title" id="axis-title" data-reveal="left">PARIS × SYDNEY — TWO INSTITUTIONAL ENVIRONMENTS. ONE ENGINE DESIGNED TO REMAIN UNIVERSAL.</h2><p class="founder-section-lead editorial" data-reveal="right">TruthX is developing from a European institutional anchor, with a France–Australia axis being built for research, pilots and deployment. Paris and Sydney are not part of the engine doctrine: they are complementary environments in which its universality can be tested.</p></div>
+        <div class="founder-axis-grid" data-reveal-group><article><span class="founder-axis-city">PARIS</span><h3>Priority European anchor</h3><p>Paris concentrates civil law, European institutions, scientific research, large organisations and complex transformations.</p><ul><li>Governance and institutional decision-making</li><li>Civil law and European regulation</li><li>Research and scientific partnerships</li><li>Priority market for missions and pilots</li></ul></article><div class="founder-axis-x" aria-hidden="true">×</div><article><span class="founder-axis-city">SYDNEY</span><h3>Developing APAC axis</h3><p>Sydney connects common law, infrastructure, delivery assurance, investigation and access to the Asia-Pacific region.</p><ul><li>Major projects and delivery assurance</li><li>Common law, insurance and eDiscovery</li><li>France–Australia research and pilots</li><li>Entry point to the APAC ecosystem</li></ul></article></div>
+        <p class="founder-axis-note">This axis describes a research and deployment strategy. It is not a claim that two established offices already exist.</p>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-verification" aria-labelledby="verification-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>08 · WHAT IS ALREADY VERIFIABLE</p><div class="founder-heading-grid"><h2 class="founder-section-title" id="verification-title" data-reveal="left">NO BLACK BOX. PUBLIC POINTS OF CONTROL.</h2><p class="founder-section-lead editorial" data-reveal="right">Credibility does not rest on a promise alone. Part of the research lineage, doctrine, output format and verification process is already publicly accessible.</p></div>
+        <div class="founder-proof-grid" data-reveal-group>
+          <a class="founder-proof-card" data-spotlight href="https://dias.users.greyc.fr/about.html" target="_blank" rel="noopener noreferrer"><span class="founder-proof-status">PUBLIC SOURCE</span><h3>GREYC / CNRS research lineage</h3><p>A research collaboration in natural language processing contributed to the genesis of TruthX Engine.</p><span class="founder-proof-cta">View the research profile ↗</span></a>
+          <a class="founder-proof-card" data-spotlight href="/truthx-engine/"><span class="founder-proof-status">PUBLIC DOCTRINE</span><h3>TruthX Engine</h3><p>The public doctrine describes the factual, decision and probative integrity engine without exposing its private implementation.</p><span class="founder-proof-cta">Read the doctrine →</span></a>
+          <a class="founder-proof-card" data-spotlight href="/"><span class="founder-proof-status">OPEN SPECIFICATION</span><h3>RPO v0.1</h3><p>The public format defines structure, canonical serialisation, reservations and the SHA-256 fingerprint.</p><span class="founder-proof-cta">Explore the specification →</span></a>
+          <a class="founder-proof-card" data-spotlight href="/tests.html"><span class="founder-proof-status">LOCAL VERIFICATION</span><h3>Independent control</h3><p>An RPO fingerprint can be recomputed locally in the browser without sending the object to OpenProof.</p><span class="founder-proof-cta">Verify an RPO →</span></a>
         </div>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-now" aria-labelledby="now-title">
+      <div class="founder-wrap">
+        <p class="founder-kicker" data-reveal>09 · WHAT SHE IS BUILDING NOW</p><div class="founder-heading-grid"><h2 class="founder-section-title" id="now-title" data-reveal="left">EVERY COMPLEX PROJECT SHOULD PRODUCE ITS OWN VERIFIABLE RECORD AS IT RUNS.</h2><p class="founder-section-lead editorial" data-reveal="right">Law is the first demonstrable vertical. The same architecture can then support major-project delivery, defects and remediation, insurance, governance, investigations and critical transformations.</p></div>
+        <div class="founder-now-grid" data-reveal-group><article class="founder-now-card" data-spotlight><span class="founder-number">01 · LEGAL</span><h3>Legal Evidence Lab</h3><p>Transform fragmented material into a factual and probative basis that legal professionals can use.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">02 · DELIVERY</span><h3>Project Delivery Integrity</h3><p>Connect requirements, milestones, decisions, corrections and evidence so divergence becomes visible before failure.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">03 · DEFECTS</span><h3>Defect &amp; Remediation Intelligence</h3><p>Trace defects, notices, inspections, responsibilities, promised remediation and verification of corrections.</p></article><article class="founder-now-card" data-spotlight><span class="founder-number">04 · EXTENSIONS</span><h3>Audit, insurance and governance</h3><p>Use the same core to understand, arbitrate, insure, audit or defend high-stakes situations.</p></article></div>
+      </div>
+    </section>
+
+    <section class="founder-chapter founder-contact" aria-labelledby="contact-title">
+      <div class="founder-wrap founder-contact-grid">
+        <div data-reveal="left"><p class="founder-kicker">10 · PILOT · MISSION · PARTNERSHIP</p><h2 class="founder-section-title" id="contact-title">WHAT MUST REMAIN DEMONSTRABLE?</h2><p class="founder-contact-copy editorial">For a real case, the OpenProof qualification path lets you describe the need without sending confidential evidence. For an Executive Advisor mission, research, integration or partnership, use the form opposite.</p><div class="founder-actions"><a class="btn primary" href="https://app.openproof.net/qualify?intent=case">Qualify a case</a><a class="btn" href="/truthx-engine/">Discover TruthX Engine</a></div></div>
         <aside class="founder-contact-aside" data-reveal="right">
-          <p class="founder-contact-copy">Gersende de Parcey works alongside leaders when facts must be reconstructed, accountability clarified and the basis for decision made more robust. She also engages with research, institutional and technology partners able to test, strengthen or deploy OpenProof.</p>
-          <div class="founder-signal-head">
-            <p class="founder-form-kicker">TRUTHX SIGNAL</p>
-            <h3>STAY CONNECTED TO THE SYSTEM.</h3>
-            <p class="founder-contact-intro">Briefly describe your situation, mission or partnership proposal. Gersende de Parcey will reply directly.</p>
-          </div>
-          <form id="rpo-contact-form-en" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="en" data-hubspot-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-page-name="Gersende de Parcey — Founder of OpenProof" data-submit-label="SUBMIT" data-sending-label="SUBMITTING…" data-error-label="Your message could not be sent. Try again or email openproof@truthx.co directly.">
-            <label>First name<input type="text" name="firstname" autocomplete="given-name" required></label>
-            <label>Last name<input type="text" name="lastname" autocomplete="family-name" required></label>
-            <label>Professional email<input type="email" name="email" autocomplete="email" required></label>
-            <label>Organisation (optional)<input type="text" name="company" autocomplete="organization"></label>
-            <label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
-            <label class="founder-form-consent">
-              <input type="checkbox" name="processingConsent" required>
-              <span><b>Request processing</b><small>I agree that TruthX and OpenProof may store and process my data in order to respond to my request.</small></span>
-            </label>
-            <label class="founder-form-consent">
-              <input type="checkbox" name="marketingConsent">
-              <span><b>TruthX publications</b><small>I would like to receive TruthX briefs and invitations. I can unsubscribe at any time.</small></span>
-            </label>
-            <button class="founder-form-submit" type="submit"><span data-submit-text>SUBMIT</span><span aria-hidden="true">→</span></button>
-            <small class="founder-form-error" role="alert" aria-live="polite"></small>
-            <small class="founder-form-note">Your data is used only to process your request and, with your consent, send TruthX publications.</small>
+          <div class="founder-signal-head"><p class="founder-form-kicker">RESEARCH · PARTNERSHIP · INTEGRATION</p><h3>BUILD, TEST OR DEPLOY THE INFRASTRUCTURE.</h3><p class="founder-contact-intro">Briefly describe your mission, research, integration or partnership proposal. Gersende de Parcey will reply directly.</p></div>
+          <form id="rpo-contact-form-en" class="founder-contact-form" data-founder-contact-form data-hs-do-not-collect="true" data-language="en" data-hubspot-form-id="87728bd0-81e1-4e96-855f-ff1e1a8c286e" data-page-name="Gersende de Parcey — Founder of OpenProof and creator of TruthX Engine" data-submit-label="SUBMIT" data-sending-label="SUBMITTING…" data-error-label="Your message could not be sent. Try again or email openproof@truthx.co directly.">
+            <label>First name<input type="text" name="firstname" autocomplete="given-name" required></label><label>Last name<input type="text" name="lastname" autocomplete="family-name" required></label><label>Professional email<input type="email" name="email" autocomplete="email" required></label><label>Organisation (optional)<input type="text" name="company" autocomplete="organization"></label><label class="founder-form-wide">Message<textarea name="message" rows="4" required></textarea></label>
+            <label class="founder-form-consent"><input type="checkbox" name="processingConsent" required><span><b>Request processing</b><small>I agree that TruthX and OpenProof may store and process my data in order to respond to my request.</small></span></label><label class="founder-form-consent"><input type="checkbox" name="marketingConsent"><span><b>TruthX publications</b><small>I would like to receive TruthX briefs and invitations. I can unsubscribe at any time.</small></span></label>
+            <button class="founder-form-submit" type="submit"><span data-submit-text>SUBMIT</span><span aria-hidden="true">→</span></button><small class="founder-form-error" role="alert" aria-live="polite"></small><small class="founder-form-note">Your data is used only to process your request and, with your consent, send TruthX publications.</small>
           </form>
-          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a>
-          <div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden>
-            <strong>REQUEST RECORDED.</strong>
-            <p>Your request has been submitted. You will be contacted directly.</p>
-          </div>
-          <noscript><p class="founder-form-noscript">To send your request, email <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
+          <a class="founder-contact-email" href="mailto:openproof@truthx.co">Email directly · openproof@truthx.co</a><div class="founder-form-success" data-form-success role="status" tabindex="-1" hidden><strong>REQUEST RECORDED.</strong><p>Your request has been submitted. You will be contacted directly.</p></div><noscript><p class="founder-form-noscript">To send your request, email <a href="mailto:openproof@truthx.co">openproof@truthx.co</a>.</p></noscript>
         </aside>
       </div>
     </section>
   </main>
 
-  <footer class="footer rpo-footer">
-    <div class="wrap">
-      <div><strong>OPENPROOF</strong><p>Probative infrastructure for critical decisions.</p></div>
-      <div class="footer-links">
-        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey on LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
-        <a href="mailto:openproof@truthx.co">Contact</a>
-        <a href="/">RPO</a>
-        <a href="https://openproof.net">OpenProof</a>
-      </div>
-    </div>
-  </footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script src="/assets/founder-reputation.js?v=20260802-2"></script>
+  <footer class="footer rpo-footer"><div class="wrap"><div><strong>OPENPROOF</strong><p>Probative infrastructure for critical decisions and projects.</p></div><div class="footer-links"><a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey on LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a><a href="mailto:openproof@truthx.co">Contact</a><a href="/truthx-engine/">TruthX Engine</a><a href="/">RPO</a><a href="https://openproof.net">OpenProof</a></div></div></footer>
+  <script src="/assets/openproof-v2.js?v=20260805-1"></script>
+  <script src="/assets/founder-reputation.js?v=20260805-1"></script>
 </body>
 </html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -75,7 +75,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/gersende-de-parcey.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html"/>
@@ -84,7 +84,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/fr/gersende-de-parcey.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/gersende-de-parcey.html"/>


### PR DESCRIPTION
## What changed

- rebuilds the French and English Founder pages around the canonical TruthX Engine doctrine
- moves the public positioning from “Executive Advisor first” to:
  - Founder of OpenProof
  - Creator of TruthX Engine
  - architect of factual, decision and probative integrity
- aligns the visual system with the RPO homepage, `/tests` and the public TruthX Engine page:
  - edge-to-edge institutional hero
  - Orbitron structural typography
  - black / ivory / warm-metal / steel palette
  - square panels and restrained separators
  - justified editorial copy on desktop
  - reduced cinematic effects and a simpler portrait treatment
- preserves a controlled human layer rather than turning the page into a technical specification

## Narrative architecture

The page now explains:

1. what Gersende sees in complex organisations;
2. what she built: factual, decision and probative integrity;
3. the two operating modes — retrospective reconstruction and continuous integrity;
4. Organizational Reality Engineering as the field method behind the engine;
5. the founding origin, condensed and system-focused rather than trauma-led;
6. the chain Gersende → TruthX Engine → OpenProof → RPO;
7. the Paris × Sydney France–Australia research and deployment axis, without claiming two established offices;
8. the public points of verification;
9. the current legal, delivery, defect/remediation, audit and governance applications;
10. separate paths for case qualification and research/partnership contact.

## Product and conversion paths

- `Discover TruthX Engine` → the new public doctrine page
- `Qualify a case` → `https://app.openproof.net/qualify?intent=case`
- mission, research, integration or partnership → the existing HubSpot-backed Founder form

## Preserved boundaries

- no change to TruthX Engine code or private rules
- no change to the HubSpot submission logic
- no confidential technical implementation disclosed
- no claim of established Paris or Sydney offices

## Validation performed

- French and English pages generated from the same structural template
- JSON-LD parsed successfully
- duplicate IDs checked
- one contact form per language preserved
- canonical and hreflang parity preserved
- CSS brace balance checked
- responsive integrity-grid correction included
- sitemap `lastmod` refreshed for both Founder URLs
