### PR TITLE
Harmonize the Founder section title hierarchy

### DIFF
--- a/docs/assets/openproof-v2.js
+++ b/docs/assets/openproof-v2.js
@@ -233,3 +233,65 @@
     document.head.append(style);
   }
 })();
+
+(() => {
+  const page = document.querySelector('.founder-page');
+  if (!page || document.getElementById('founder-title-hierarchy')) return;
+
+  const style = document.createElement('style');
+  style.id = 'founder-title-hierarchy';
+  style.textContent = `
+    .founder-page .founder-section-title{
+      max-width:900px;
+      font-size:clamp(2.15rem,3vw,3rem);
+      line-height:1.08;
+      letter-spacing:-.03em;
+      text-wrap:balance;
+      overflow-wrap:normal;
+      word-break:normal;
+      hyphens:none;
+      -webkit-hyphens:none;
+    }
+    .founder-page .founder-method-grid{
+      grid-template-columns:minmax(0,.9fr) minmax(560px,1.1fr);
+      gap:72px;
+    }
+    .founder-page .founder-method .founder-section-title{
+      max-width:540px;
+      font-size:clamp(2.15rem,3vw,3rem);
+    }
+    .founder-page .founder-contact-grid{
+      grid-template-columns:minmax(0,.92fr) minmax(520px,1.08fr);
+      gap:72px;
+    }
+    .founder-page .founder-contact .founder-section-title{
+      max-width:570px;
+      font-size:clamp(2.15rem,3vw,3rem);
+    }
+    .founder-page .founder-origin .founder-section-title{
+      max-width:670px;
+    }
+    @media(max-width:1180px){
+      .founder-page .founder-section-title,
+      .founder-page .founder-method .founder-section-title,
+      .founder-page .founder-contact .founder-section-title{
+        max-width:780px;
+        font-size:clamp(2.1rem,4.7vw,3.3rem);
+      }
+      .founder-page .founder-method-grid,
+      .founder-page .founder-contact-grid{
+        grid-template-columns:1fr;
+        gap:42px;
+      }
+    }
+    @media(max-width:760px){
+      .founder-page .founder-section-title,
+      .founder-page .founder-method .founder-section-title,
+      .founder-page .founder-contact .founder-section-title{
+        max-width:100%;
+        font-size:clamp(1.95rem,9.6vw,2.8rem);
+        line-height:1.08;
+      }
+    }`;
+  document.head.append(style);
+})();


### PR DESCRIPTION
## Visual correction

The Founder hero remains the only level-one title. All internal section headings now share one stable level-two scale, using the successful `Organizational Reality Engineering` treatment as the visual reference.

## Changes

- applies one consistent title size, line-height and tracking to every internal Founder section;
- preserves different maximum widths only where the grid requires them;
- rebalances the method and contact grids so titles no longer collide with the question matrix or form;
- corrects the final `What must remain demonstrable?` / `Quelle situation doit rester démontrable ?` section without weakening its importance;
- balances line wrapping and prevents broken words or clipping;
- applies the same hierarchy to French and English;
- keeps the hero, doctrine, text, forms, CTAs and approved visual charter unchanged.

## Scope

One shared JavaScript file is changed. The new Founder-only style override is injected after the existing page styles so no other OpenProof page is affected.