### PR TITLE
Make the RPO example and verification understandable

### DIFF
--- a/docs/assets/rpo-demonstration-copy.css
+++ b/docs/assets/rpo-demonstration-copy.css
@@ -1,0 +1,13 @@
+/* Editorial alignment requested for the public RPO demonstration pages. */
+@media(min-width:821px){
+  .rpo-demo-page main p:not(.demo-kicker):not(.demo-index),
+  .rpo-verify-page main p:not(.demo-kicker):not(.demo-index),
+  .rpo-demo-page main li,
+  .rpo-verify-page main li{
+    text-align:justify;
+    text-align-last:left;
+    text-justify:inter-word;
+    hyphens:auto;
+    -webkit-hyphens:auto;
+  }
+}

--- a/docs/assets/rpo-demonstration.css
+++ b/docs/assets/rpo-demonstration.css
@@ -1,0 +1,783 @@
+/*
+ * OpenProof public demonstration — human-readable RPO example and local verification.
+ * Page-scoped extension of the canonical RPO / OpenProof visual system.
+ */
+
+.rpo-demo-page,
+.rpo-verify-page{
+  background:#050709;
+  color:var(--ink);
+}
+
+.rpo-demo-page main h1,
+.rpo-demo-page main h2,
+.rpo-demo-page main h3,
+.rpo-verify-page main h1,
+.rpo-verify-page main h2,
+.rpo-verify-page main h3,
+.demo-kicker,
+.demo-index,
+.demo-label,
+.verify-label{
+  font-family:Orbitron,Montserrat,sans-serif;
+}
+
+.demo-wrap{
+  width:min(1240px,calc(100% - 12vw));
+  margin:auto;
+}
+
+.demo-kicker,
+.demo-index{
+  margin:0;
+  color:var(--gold);
+  font-size:7px;
+  font-weight:700;
+  line-height:1.45;
+  letter-spacing:2.2px;
+  text-transform:uppercase;
+}
+
+.demo-section{
+  padding:102px 0;
+  border-top:1px solid var(--line);
+}
+
+.demo-section:nth-of-type(odd){
+  background:#080b0f;
+}
+
+.demo-section:nth-of-type(even){
+  background:#0d1217;
+}
+
+.demo-heading-grid{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) minmax(320px,.42fr);
+  gap:68px;
+  align-items:end;
+  margin-bottom:42px;
+}
+
+.demo-heading-grid h2,
+.demo-section> .demo-wrap>h2{
+  max-width:910px;
+  margin:16px 0 0;
+  color:#ece8df;
+  font:500 clamp(2.1rem,3.2vw,3.35rem)/1.08 Orbitron,Montserrat,sans-serif;
+  letter-spacing:-.03em;
+  text-transform:uppercase;
+  text-wrap:balance;
+}
+
+.demo-heading-grid>p,
+.demo-section-lead{
+  margin:0 0 8px;
+  color:var(--soft);
+  font-size:.94rem;
+  line-height:1.88;
+}
+
+@media(min-width:821px){
+  .demo-editorial,
+  .demo-heading-grid>p,
+  .demo-section-lead,
+  .demo-story-card p,
+  .demo-value-card p,
+  .demo-anatomy-card p,
+  .demo-human-copy p,
+  .demo-boundary p,
+  .verify-step p,
+  .verify-control-copy p,
+  .verify-proof-card p,
+  .verify-note{
+    text-align:justify;
+    text-align-last:left;
+    text-justify:inter-word;
+    hyphens:auto;
+    -webkit-hyphens:auto;
+  }
+}
+
+/* Hero */
+.demo-hero{
+  min-height:690px;
+  padding:0;
+  display:flex;
+  align-items:stretch;
+  border-bottom:1px solid var(--line);
+}
+
+.demo-hero>.demo-wrap{
+  display:grid;
+  grid-template-columns:minmax(560px,1fr) minmax(390px,.72fr);
+  gap:5vw;
+  align-items:center;
+  min-height:690px;
+  padding:90px 0 92px;
+}
+
+.demo-hero-copy h1{
+  max-width:880px;
+  margin:23px 0 30px;
+  color:#ece8df;
+  font:500 clamp(51px,5.1vw,76px)/.98 Orbitron,Montserrat,sans-serif;
+  letter-spacing:-.035em;
+  text-transform:uppercase;
+  text-shadow:0 4px 35px #000;
+}
+
+.demo-hero-copy h1 span{
+  display:block;
+  margin-top:16px;
+  color:var(--gold);
+  font-size:.48em;
+  line-height:1.16;
+  letter-spacing:-.02em;
+}
+
+.demo-hero-lead{
+  max-width:690px;
+  margin:0;
+  color:#9ca4a5;
+  font-size:14px;
+  line-height:1.9;
+  letter-spacing:.15px;
+}
+
+.demo-actions{
+  display:flex;
+  align-items:center;
+  gap:14px 28px;
+  flex-wrap:wrap;
+  margin-top:36px;
+}
+
+.demo-actions .btn{
+  min-height:48px;
+  padding:15px 21px;
+  border-radius:0;
+}
+
+.demo-one-line{
+  margin:26px 0 0;
+  padding:18px 20px;
+  border-left:2px solid var(--gold);
+  background:rgba(196,154,88,.055);
+  color:#c8cbc7;
+  font-size:.86rem;
+  line-height:1.72;
+}
+
+/* Hero visual: one situation viewed through four states */
+.demo-visual{
+  position:relative;
+  display:grid;
+  place-items:center;
+  min-height:480px;
+}
+
+.demo-visual-ring{
+  position:absolute;
+  border-radius:50%;
+  border:1px solid rgba(172,154,112,.20);
+}
+
+.demo-visual-ring--outer{
+  width:430px;
+  height:430px;
+}
+
+.demo-visual-ring--inner{
+  width:285px;
+  height:285px;
+  border-color:rgba(133,150,156,.15);
+}
+
+.demo-visual-core{
+  position:relative;
+  z-index:2;
+  display:grid;
+  place-items:center;
+  width:170px;
+  height:170px;
+  border:1px solid #d8bc7b;
+  border-radius:50%;
+  background:radial-gradient(circle at 48% 42%,#283038,#0a0e12 63%);
+  box-shadow:inset 0 0 45px rgba(210,174,96,.15),0 0 70px rgba(177,140,70,.12),0 0 0 12px rgba(185,155,92,.04);
+  color:#e2c98e;
+  text-align:center;
+}
+
+.demo-visual-core strong{
+  font:600 .86rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.15em;
+}
+
+.demo-visual-core span{
+  display:block;
+  margin-top:8px;
+  color:#70797d;
+  font:600 .55rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.14em;
+}
+
+.demo-node{
+  position:absolute;
+  display:flex;
+  align-items:center;
+  gap:9px;
+  color:#7b8487;
+  font:600 7px/1.4 Orbitron,Montserrat,sans-serif;
+  letter-spacing:1.25px;
+  text-transform:uppercase;
+}
+
+.demo-node::before{
+  width:5px;
+  height:5px;
+  border-radius:50%;
+  background:#c7a65f;
+  box-shadow:0 0 10px #d5af60;
+  content:"";
+}
+
+.demo-node--expected{top:13%;left:44%}
+.demo-node--declared{top:33%;right:0}
+.demo-node--evidence{bottom:22%;right:5%}
+.demo-node--unresolved{bottom:15%;left:2%}
+
+/* Situation */
+.demo-story-grid{
+  display:grid;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  border-block:1px solid var(--line);
+}
+
+.demo-story-card{
+  min-height:300px;
+  padding:30px 27px 28px;
+  border-right:1px solid var(--line);
+  background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96));
+}
+
+.demo-story-card:last-child{border-right:0}
+
+.demo-story-card .demo-label,
+.demo-value-card .demo-label,
+.demo-anatomy-card .demo-label{
+  color:var(--gold);
+  font-size:.61rem;
+  letter-spacing:.13em;
+  text-transform:uppercase;
+}
+
+.demo-story-card h3,
+.demo-value-card h3,
+.demo-anatomy-card h3{
+  margin:29px 0 16px;
+  color:var(--pale);
+  font-size:1rem;
+  line-height:1.45;
+}
+
+.demo-story-card p,
+.demo-value-card p,
+.demo-anatomy-card p{
+  margin:0;
+  color:var(--soft);
+  font-size:.89rem;
+  line-height:1.82;
+}
+
+.demo-story-card--alert{
+  box-shadow:inset 0 -2px 0 rgba(196,154,88,.75);
+}
+
+/* Value */
+.demo-value-grid{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  border:1px solid var(--line);
+}
+
+.demo-value-card{
+  min-height:250px;
+  padding:31px 29px;
+  border-right:1px solid var(--line);
+  background:#080b0f;
+}
+
+.demo-value-card:last-child{border-right:0}
+
+/* Anatomy */
+.demo-anatomy-grid{
+  display:grid;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  border-block:1px solid var(--line);
+}
+
+.demo-anatomy-card{
+  min-height:280px;
+  padding:30px 27px;
+  border-right:1px solid var(--line);
+  background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96));
+}
+
+.demo-anatomy-card:last-child{border-right:0}
+
+/* Human and machine views */
+.demo-readable-grid{
+  display:grid;
+  grid-template-columns:minmax(0,.88fr) minmax(480px,1.12fr);
+  gap:78px;
+  align-items:start;
+}
+
+.demo-human-card{
+  border-left:2px solid var(--gold);
+  background:rgba(196,154,88,.055);
+  padding:28px 30px;
+}
+
+.demo-human-card h3{
+  margin:0 0 18px;
+  color:var(--pale);
+  font-size:1.05rem;
+}
+
+.demo-human-copy p{
+  margin:0 0 18px;
+  color:#c1c4c0;
+  font-size:.94rem;
+  line-height:1.85;
+}
+
+.demo-human-copy p:last-child{margin-bottom:0}
+
+.demo-tech-summary{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  border-top:1px solid var(--line);
+}
+
+.demo-tech-summary>div{
+  min-height:112px;
+  padding:20px 22px;
+  border-right:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+}
+
+.demo-tech-summary>div:nth-child(2n){border-right:0}
+
+.demo-tech-summary span{
+  display:block;
+  color:var(--muted);
+  font-size:.66rem;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+
+.demo-tech-summary strong{
+  display:block;
+  margin-top:10px;
+  color:#ddd9d0;
+  font:500 .82rem/1.55 ui-monospace,SFMono-Regular,Menlo,monospace;
+  overflow-wrap:anywhere;
+}
+
+.demo-json-details{
+  margin-top:28px;
+  border:1px solid var(--line);
+  background:#05080b;
+}
+
+.demo-json-details summary{
+  cursor:pointer;
+  list-style:none;
+  padding:19px 21px;
+  color:var(--pale);
+  font:600 .69rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.09em;
+  text-transform:uppercase;
+}
+
+.demo-json-details summary::-webkit-details-marker{display:none}
+.demo-json-details summary::after{float:right;color:var(--gold);content:"+"}
+.demo-json-details[open] summary::after{content:"−"}
+
+.demo-code-head{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:13px 17px;
+  border-top:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+  color:var(--muted);
+  font:600 .61rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.09em;
+}
+
+.demo-code-head button{
+  border:0;
+  background:transparent;
+  color:var(--pale);
+  cursor:pointer;
+  font:600 .59rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.09em;
+}
+
+.demo-json{
+  max-height:560px;
+  margin:0;
+  padding:22px;
+  overflow:auto;
+  color:#c7cdca;
+  font:500 .76rem/1.65 ui-monospace,SFMono-Regular,Menlo,monospace;
+  white-space:pre;
+}
+
+.demo-boundary{
+  padding:28px 0;
+  border-top:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+  background:#050709;
+}
+
+.demo-boundary .demo-wrap{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) auto;
+  gap:40px;
+  align-items:center;
+}
+
+.demo-boundary p{
+  margin:0;
+  color:var(--soft);
+  font-size:.9rem;
+  line-height:1.8;
+}
+
+.demo-boundary strong{color:var(--pale)}
+
+/* Verification explainer */
+.verify-steps{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  border:1px solid var(--line);
+}
+
+.verify-step{
+  min-height:250px;
+  padding:31px 29px;
+  border-right:1px solid var(--line);
+  background:#080b0f;
+}
+
+.verify-step:last-child{border-right:0}
+
+.verify-step b{
+  color:var(--gold);
+  font:600 .68rem Orbitron,Montserrat,sans-serif;
+}
+
+.verify-step h3{
+  margin:28px 0 16px;
+  color:var(--pale);
+  font-size:1rem;
+}
+
+.verify-step p{
+  margin:0;
+  color:var(--soft);
+  font-size:.89rem;
+  line-height:1.82;
+}
+
+/* Verification laboratory */
+.verify-lab{
+  display:grid;
+  grid-template-columns:minmax(360px,.74fr) minmax(560px,1.26fr);
+  gap:70px;
+  align-items:start;
+}
+
+.verify-control{
+  position:sticky;
+  top:36px;
+  border:1px solid var(--line);
+  background:#080b0f;
+}
+
+.verify-control-head{
+  padding:27px 28px;
+  border-bottom:1px solid var(--line);
+}
+
+.verify-control-head h3{
+  margin:13px 0 0;
+  color:var(--pale);
+  font-size:1.1rem;
+}
+
+.verify-control-copy{
+  padding:25px 28px;
+}
+
+.verify-control-copy p{
+  margin:0;
+  color:var(--soft);
+  font-size:.9rem;
+  line-height:1.82;
+}
+
+.verify-buttons{
+  display:grid;
+  gap:10px;
+  padding:0 28px 28px;
+}
+
+.verify-buttons .btn{
+  width:100%;
+  min-height:48px;
+  border-radius:0;
+}
+
+.verify-buttons .btn[data-action="mutate"]{
+  border-color:rgba(196,154,88,.55);
+  color:var(--pale);
+}
+
+.verify-report{
+  border-top:1px solid var(--line);
+}
+
+.verify-state{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  min-height:80px;
+  padding:22px 24px;
+  border-right:1px solid var(--line);
+  border-left:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+  color:var(--muted);
+  font:600 .75rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.09em;
+}
+
+.verify-state i{
+  width:11px;
+  height:11px;
+  border-radius:50%;
+  background:currentColor;
+  box-shadow:0 0 18px currentColor;
+}
+
+.verify-state.success{color:var(--green)}
+.verify-state.warning{color:var(--gold)}
+.verify-state.failure{color:#ff7a7a}
+
+.verify-result-grid{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+}
+
+.verify-result{
+  min-height:142px;
+  padding:22px 24px;
+  border-right:1px solid var(--line);
+  border-bottom:1px solid var(--line);
+}
+
+.verify-result:nth-child(2n){border-right:0}
+
+.verify-result dt{
+  color:var(--muted);
+  font-size:.68rem;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+
+.verify-result dd{
+  margin:12px 0 0;
+  color:#d6d9d5;
+  font:500 .79rem/1.65 ui-monospace,SFMono-Regular,Menlo,monospace;
+  overflow-wrap:anywhere;
+}
+
+.verify-result--hash{
+  grid-column:1/-1;
+  border-right:0;
+}
+
+.verify-result--hash dd{color:var(--gold)}
+
+.verify-reference{
+  margin-top:22px;
+  padding:19px 21px;
+  border-left:2px solid var(--gold);
+  background:rgba(196,154,88,.055);
+  color:var(--soft);
+  font-size:.82rem;
+  line-height:1.72;
+}
+
+.verify-advanced{
+  margin-top:26px;
+  border:1px solid var(--line);
+  background:#05080b;
+}
+
+.verify-advanced summary{
+  cursor:pointer;
+  list-style:none;
+  padding:19px 21px;
+  color:var(--pale);
+  font:600 .68rem Orbitron,Montserrat,sans-serif;
+  letter-spacing:.09em;
+  text-transform:uppercase;
+}
+
+.verify-advanced summary::-webkit-details-marker{display:none}
+.verify-advanced summary::after{float:right;color:var(--gold);content:"+"}
+.verify-advanced[open] summary::after{content:"−"}
+
+.verify-editor{
+  width:100%;
+  min-height:420px;
+  padding:22px;
+  border:0;
+  border-top:1px solid var(--line);
+  outline:0;
+  resize:vertical;
+  background:#05080b;
+  color:#c7cdca;
+  font:500 .76rem/1.65 ui-monospace,SFMono-Regular,Menlo,monospace;
+}
+
+.verify-editor-actions{
+  display:flex;
+  gap:12px;
+  padding:15px 18px 18px;
+  border-top:1px solid var(--line);
+}
+
+.verify-editor-actions .btn{
+  min-height:44px;
+  border-radius:0;
+}
+
+.verify-proof-grid{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  border:1px solid var(--line);
+}
+
+.verify-proof-card{
+  min-height:300px;
+  padding:32px 31px;
+  background:#080b0f;
+}
+
+.verify-proof-card:first-child{border-right:1px solid var(--line)}
+
+.verify-proof-card h3{
+  margin:0 0 22px;
+  color:var(--pale);
+  font-size:1.05rem;
+}
+
+.verify-proof-card ul{
+  margin:0;
+  padding-left:20px;
+}
+
+.verify-proof-card li,
+.verify-proof-card p{
+  margin:0 0 12px;
+  color:var(--soft);
+  font-size:.9rem;
+  line-height:1.78;
+}
+
+.verify-proof-card--limit{
+  background:#0d1217;
+}
+
+.verify-note{
+  margin:22px 0 0;
+  color:var(--muted);
+  font-size:.76rem;
+  line-height:1.7;
+}
+
+@media(max-width:1080px){
+  .demo-hero>.demo-wrap,
+  .demo-readable-grid,
+  .verify-lab,
+  .demo-heading-grid{
+    grid-template-columns:1fr;
+  }
+  .demo-visual{min-height:430px}
+  .demo-story-grid,
+  .demo-anatomy-grid{grid-template-columns:repeat(2,1fr)}
+  .demo-story-card:nth-child(2),
+  .demo-anatomy-card:nth-child(2){border-right:0}
+  .demo-story-card,
+  .demo-anatomy-card{border-bottom:1px solid var(--line)}
+  .demo-story-card:nth-last-child(-n+2),
+  .demo-anatomy-card:nth-last-child(-n+2){border-bottom:0}
+  .verify-control{position:static}
+}
+
+@media(max-width:820px){
+  .demo-wrap{width:calc(100% - 44px)}
+  .demo-section{padding:74px 0}
+  .demo-hero{min-height:auto}
+  .demo-hero>.demo-wrap{min-height:auto;padding:68px 0 76px}
+  .demo-hero-copy h1{font-size:43px}
+  .demo-heading-grid h2,
+  .demo-section>.demo-wrap>h2{font-size:clamp(2rem,10vw,3rem)}
+  .demo-story-grid,
+  .demo-value-grid,
+  .demo-anatomy-grid,
+  .verify-steps,
+  .verify-result-grid,
+  .verify-proof-grid{
+    grid-template-columns:1fr;
+  }
+  .demo-story-card,
+  .demo-value-card,
+  .demo-anatomy-card,
+  .verify-step,
+  .verify-result,
+  .verify-proof-card:first-child{
+    min-height:auto;
+    border-right:0;
+    border-bottom:1px solid var(--line);
+  }
+  .demo-story-card:last-child,
+  .demo-value-card:last-child,
+  .demo-anatomy-card:last-child,
+  .verify-step:last-child,
+  .verify-result:last-child,
+  .verify-proof-card:last-child{border-bottom:0}
+  .verify-result--hash{grid-column:auto}
+  .demo-boundary .demo-wrap{grid-template-columns:1fr}
+}
+
+@media(max-width:520px){
+  .demo-hero-copy h1{font-size:37px}
+  .demo-actions{align-items:stretch}
+  .demo-actions .btn{width:100%}
+  .demo-visual{min-height:360px}
+  .demo-visual-ring--outer{width:300px;height:300px}
+  .demo-visual-ring--inner{width:210px;height:210px}
+  .demo-visual-core{width:138px;height:138px}
+  .demo-node{font-size:6px}
+  .demo-tech-summary{grid-template-columns:1fr}
+  .demo-tech-summary>div{border-right:0}
+  .verify-editor-actions{flex-direction:column}
+  .verify-editor-actions .btn{width:100%}
+}

--- a/docs/assets/rpo-demonstration.js
+++ b/docs/assets/rpo-demonstration.js
@@ -1,0 +1,224 @@
+(() => {
+  const page = document.querySelector('[data-rpo-demo-page]');
+  if (!page) return;
+
+  const isFrench = document.documentElement.lang.toLowerCase().startsWith('fr');
+  const source = page.dataset.demoSrc;
+  const copy = isFrench
+    ? {
+        unavailable: 'La démonstration publique est momentanément indisponible.',
+        copied: 'COPIÉ',
+        copy: 'COPIER LE JSON',
+        readable: 'LISIBLE',
+        invalid: 'JSON INVALIDE',
+        complete: 'STRUCTURE DE BASE PRÉSENTE',
+        incomplete: 'STRUCTURE INCOMPLÈTE',
+        unchanged: 'COPIE IDENTIQUE À LA RÉFÉRENCE',
+        changed: 'MODIFICATION DÉTECTÉE',
+        ready: 'DÉMONSTRATION PRÊTE',
+        error: 'VÉRIFICATION IMPOSSIBLE',
+        simulated: 'Une phrase de démonstration a été modifiée.',
+        evidence: count => `${count} RÉFÉRENCES`,
+        restored: 'La copie publique d’origine a été restaurée.'
+      }
+    : {
+        unavailable: 'The public demonstration is temporarily unavailable.',
+        copied: 'COPIED',
+        copy: 'COPY JSON',
+        readable: 'READABLE',
+        invalid: 'INVALID JSON',
+        complete: 'BASIC STRUCTURE PRESENT',
+        incomplete: 'STRUCTURE INCOMPLETE',
+        unchanged: 'IDENTICAL TO REFERENCE COPY',
+        changed: 'CHANGE DETECTED',
+        ready: 'DEMONSTRATION READY',
+        error: 'VERIFICATION FAILED',
+        simulated: 'One demonstration sentence has been changed.',
+        evidence: count => `${count} REFERENCES`,
+        restored: 'The original public copy has been restored.'
+      };
+
+  const stable = value => {
+    if (Array.isArray(value)) return '[' + value.map(stable).join(',') + ']';
+    if (value && typeof value === 'object') {
+      return '{' + Object.keys(value).sort().map(key => JSON.stringify(key) + ':' + stable(value[key])).join(',') + '}';
+    }
+    return JSON.stringify(value);
+  };
+
+  const digest = async text => {
+    const bytes = new TextEncoder().encode(text);
+    const hash = await crypto.subtle.digest('SHA-256', bytes);
+    return {
+      bytes: bytes.byteLength,
+      hex: [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2, '0')).join('')
+    };
+  };
+
+  const required = ['rpo_version', 'type', 'bundle_id', 'created_at', 'issuer', 'subject', 'evidence', 'narrative'];
+
+  let originalText = '';
+  let originalObject = null;
+  let referenceHash = '';
+
+  const fillExampleView = object => {
+    const raw = document.querySelector('#demoJson');
+    if (raw) raw.textContent = JSON.stringify(object, null, 2);
+
+    const fields = {
+      version: object.rpo_version || '—',
+      bundle: object.bundle_id || '—',
+      subject: object.subject?.name || '—',
+      evidence: copy.evidence(Array.isArray(object.evidence) ? object.evidence.length : 0)
+    };
+
+    Object.entries(fields).forEach(([name, value]) => {
+      document.querySelectorAll(`[data-demo-field="${name}"]`).forEach(element => {
+        element.textContent = value;
+      });
+    });
+  };
+
+  const setState = (kind, label) => {
+    const state = document.querySelector('#verificationState');
+    if (!state) return;
+    state.className = `verify-state ${kind || ''}`.trim();
+    const text = state.querySelector('span');
+    if (text) text.textContent = label;
+  };
+
+  const basicStructure = object => {
+    const missing = required.filter(field => !(field in object));
+    if (object.rpo_version !== '0.1') missing.push('rpo_version=0.1');
+    if (object.type !== 'evidence_bundle') missing.push('type=evidence_bundle');
+    if (!Array.isArray(object.evidence)) missing.push('evidence[]');
+    return [...new Set(missing)];
+  };
+
+  const verifyText = async text => {
+    const syntaxResult = document.querySelector('#syntaxResult');
+    const structureResult = document.querySelector('#structureResult');
+    const matchResult = document.querySelector('#matchResult');
+    const hashResult = document.querySelector('#hashResult');
+    const bytesResult = document.querySelector('#bytesResult');
+
+    try {
+      const object = JSON.parse(text);
+      if (syntaxResult) syntaxResult.textContent = copy.readable;
+
+      const missing = basicStructure(object);
+      if (structureResult) {
+        structureResult.textContent = missing.length
+          ? `${copy.incomplete} · ${missing.join(', ')}`
+          : copy.complete;
+      }
+
+      const result = await digest(stable(object));
+      if (hashResult) hashResult.textContent = result.hex;
+      if (bytesResult) bytesResult.textContent = result.bytes.toLocaleString(isFrench ? 'fr-FR' : 'en-GB');
+
+      const matches = Boolean(referenceHash) && result.hex === referenceHash;
+      if (matchResult) matchResult.textContent = matches ? copy.unchanged : copy.changed;
+
+      if (missing.length) setState('warning', copy.incomplete);
+      else if (matches) setState('success', copy.unchanged);
+      else setState('warning', copy.changed);
+
+      return object;
+    } catch (error) {
+      if (syntaxResult) syntaxResult.textContent = copy.invalid;
+      if (structureResult) structureResult.textContent = '—';
+      if (matchResult) matchResult.textContent = '—';
+      if (hashResult) hashResult.textContent = '—';
+      if (bytesResult) bytesResult.textContent = '—';
+      setState('failure', copy.error);
+      return null;
+    }
+  };
+
+  const setEditor = text => {
+    const editor = document.querySelector('#rpoEditor');
+    if (editor) editor.value = text;
+  };
+
+  const runEditor = () => {
+    const editor = document.querySelector('#rpoEditor');
+    if (editor) verifyText(editor.value);
+  };
+
+  const load = async () => {
+    if (!source) return;
+    try {
+      const response = await fetch(source, { cache: 'no-store' });
+      if (!response.ok) throw new Error('demo fetch failed');
+      originalText = await response.text();
+      originalObject = JSON.parse(originalText);
+      referenceHash = (await digest(stable(originalObject))).hex;
+
+      fillExampleView(originalObject);
+      setEditor(JSON.stringify(originalObject, null, 2));
+
+      const reference = document.querySelector('#referenceHash');
+      if (reference) reference.textContent = referenceHash;
+
+      if (document.querySelector('#verificationState')) {
+        await verifyText(JSON.stringify(originalObject, null, 2));
+      }
+    } catch (error) {
+      const raw = document.querySelector('#demoJson');
+      if (raw) raw.textContent = copy.unavailable;
+      setState('failure', copy.error);
+    }
+  };
+
+  document.querySelector('#copyDemoJson')?.addEventListener('click', async event => {
+    if (!originalText) return;
+    await navigator.clipboard.writeText(originalText);
+    event.currentTarget.textContent = copy.copied;
+    window.setTimeout(() => {
+      event.currentTarget.textContent = copy.copy;
+    }, 1200);
+  });
+
+  document.querySelectorAll('[data-action="check-original"]').forEach(button => {
+    button.addEventListener('click', async () => {
+      if (!originalObject) return;
+      const text = JSON.stringify(originalObject, null, 2);
+      setEditor(text);
+      await verifyText(text);
+    });
+  });
+
+  document.querySelectorAll('[data-action="mutate"]').forEach(button => {
+    button.addEventListener('click', async () => {
+      if (!originalObject) return;
+      const changed = JSON.parse(JSON.stringify(originalObject));
+      changed.narrative.summary = isFrench
+        ? `${changed.narrative.summary} [DÉTAIL MODIFIÉ]`
+        : `${changed.narrative.summary} [DETAIL CHANGED]`;
+      const text = JSON.stringify(changed, null, 2);
+      setEditor(text);
+      await verifyText(text);
+
+      const advanced = document.querySelector('.verify-advanced');
+      if (advanced && !advanced.open) advanced.open = true;
+      const note = document.querySelector('#simulationNote');
+      if (note) note.textContent = copy.simulated;
+    });
+  });
+
+  document.querySelectorAll('[data-action="restore"]').forEach(button => {
+    button.addEventListener('click', async () => {
+      if (!originalObject) return;
+      const text = JSON.stringify(originalObject, null, 2);
+      setEditor(text);
+      await verifyText(text);
+      const note = document.querySelector('#simulationNote');
+      if (note) note.textContent = copy.restored;
+    });
+  });
+
+  document.querySelector('#runVerification')?.addEventListener('click', runEditor);
+
+  load();
+})();

--- a/docs/assets/rpo-demonstration.js
+++ b/docs/assets/rpo-demonstration.js
@@ -2,6 +2,13 @@
   const page = document.querySelector('[data-rpo-demo-page]');
   if (!page) return;
 
+  if (!document.querySelector('link[href*="rpo-demonstration-copy.css"]')) {
+    const editorialStyles = document.createElement('link');
+    editorialStyles.rel = 'stylesheet';
+    editorialStyles.href = '/assets/rpo-demonstration-copy.css?v=20260805-1';
+    document.head.append(editorialStyles);
+  }
+
   const isFrench = document.documentElement.lang.toLowerCase().startsWith('fr');
   const source = page.dataset.demoSrc;
   const copy = isFrench

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -4,56 +4,51 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>RPO Example: Evidence Manifest &amp; SHA-256 | OpenProof</title>
-  <meta name="description" content="Inspect a public RPO example: sealed core, evidence manifest, provenance, explicit reservations and a public SHA-256 integrity fingerprint.">
+  <title>See an RPO in Plain Language | OpenProof</title>
+  <meta name="description" content="Understand what a Registered Probative Object preserves: the situation, sources, contradiction, unresolved point and integrity fingerprint.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/examples.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/examples.html">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/examples.html">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/examples.html">
-<meta property="og:type" content="article">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/examples.html">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/examples.html">
+  <meta property="og:type" content="article">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="RPO Example: Evidence Manifest &amp; SHA-256">
-  <meta property="og:description" content="Inspect a public RPO example: sealed core, evidence manifest, provenance, explicit reservations and a public SHA-256 integrity fingerprint.">
+  <meta property="og:title" content="An RPO explained in plain language">
+  <meta property="og:description" content="Understand what a Registered Probative Object preserves: the situation, sources, contradiction, unresolved point and integrity fingerprint.">
   <meta property="og:url" content="https://rpo.openproof.net/examples.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="RPO Example: Evidence Manifest &amp; SHA-256">
-  <meta name="twitter:description" content="Inspect a public RPO example: sealed core, evidence manifest, provenance, explicit reservations and a public SHA-256 integrity fingerprint.">
+  <meta name="twitter:title" content="An RPO explained in plain language">
+  <meta name="twitter:description" content="Understand what a Registered Probative Object preserves: the situation, sources, contradiction, unresolved point and integrity fingerprint.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "headline": "Registered Probative Object (RPO) Public Example",
-  "description": "A minimal RPO example containing a sealed core, evidence manifest, reservations and public SHA-256 integrity hash.",
-  "url": "https://rpo.openproof.net/examples.html",
-  "author": {
-    "@type": "Organization",
-    "name": "OpenProof",
-    "url": "https://openproof.net"
-  },
-  "isPartOf": {
-    "@id": "https://rpo.openproof.net/#website"
-  },
-  "about": [
-    "Registered Probative Object",
-    "evidence manifest",
-    "evidence provenance",
-    "SHA-256"
-  ],
-  "inLanguage": "en"
-}
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "name": "Public Registered Probative Object demonstration",
+    "headline": "Public Registered Probative Object demonstration",
+    "url": "https://rpo.openproof.net/examples.html",
+    "description": "Understand what a Registered Probative Object preserves: the situation, sources, contradiction, unresolved point and integrity fingerprint.",
+    "version": "0.1",
+    "isAccessibleForFree": true,
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "inLanguage": "en"
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="en_US">
-<meta property="og:locale:alternate" content="fr_FR">
+  <link rel="stylesheet" href="/assets/rpo-demonstration.css?v=20260805-1">
 </head>
-<body class="rpo-home rpo-subpage">
+<body class="rpo-home rpo-subpage rpo-demo-page" data-rpo-demo-page data-demo-src="/examples/public-demo/rpo-en.json">
   <a class="skip" href="#main">Skip to content</a>
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
@@ -61,108 +56,142 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Open menu">Menu</button>
       <div class="links">
-        <a href="/">Specification</a><a href="/examples.html" aria-current="page">Example</a><a href="/tests.html">Verify</a><a href="/gersende-de-parcey.html">Founder</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/">Specification</a>
+        <a href="/examples.html" aria-current="page">See an RPO</a>
+        <a href="/tests.html">Verify an RPO</a>
+        <a href="/gersende-de-parcey.html">Founder</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Language">
-<a href="/fr/examples.html" lang="fr" hreflang="fr">FR</a><span aria-hidden="true">|</span><a href="/examples.html" lang="en" hreflang="en" aria-current="page">EN</a>
-</div>
+        <a href="/fr/examples.html" lang="fr" hreflang="fr">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/examples.html" lang="en" hreflang="en" aria-current="page">EN</a>
+      </div>
     </div>
   </nav>
 
   <main id="main">
-    <header class="sub-hero cosmos">
+    <header class="demo-hero cosmos">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap">
-        <p class="eyebrow">02 · EXAMPLE · RPO V0.1</p>
-        <h1>
-          <span>One RPO, made readable.</span>
-        </h1>
-        <p class="sub-lead">A minimal object exposes the public structure without disclosing a real case. The same file can be read by a person, a machine and the verification tool.</p>
-        <div class="sub-actions">
-          <a class="btn primary" href="/tests.html">Verify this object</a>
-          <a class="btn" href="https://github.com/openproof-net/rpo-spec-v0.1/blob/main/examples/example-minimal/rpo.json">Raw JSON ↗</a>
+      <div class="demo-wrap">
+        <div class="demo-hero-copy">
+          <p class="demo-kicker">02 · SEE AN RPO · FICTIONAL DATA</p>
+          <h1>WHAT DOES AN RPO ACTUALLY SHOW?<span>START WITH THE SITUATION, NOT THE CODE.</span></h1>
+          <p class="demo-hero-lead">An RPO is neither “the truth” nor a legal conclusion. It is a structured record preserving what was expected, what was declared, what the sources show and what remains unresolved.</p>
+          <div class="demo-actions">
+            <a class="btn primary" href="#situation">Read the situation</a>
+            <a class="btn" href="/tests.html#laboratory">Verify this copy</a>
+          </div>
+          <p class="demo-one-line">In one sentence: the RPO keeps the situation, sources, limits and change-detection fingerprint together.</p>
+        </div>
+        <div class="demo-visual" aria-label="RPO demonstration">
+          <div class="demo-visual-ring demo-visual-ring--outer"></div>
+          <div class="demo-visual-ring demo-visual-ring--inner"></div>
+          <div class="demo-visual-core"><div><strong>RPO</strong><span>VERIFIABLE STATE</span></div></div>
+          <span class="demo-node demo-node--expected">EXPECTED</span>
+          <span class="demo-node demo-node--declared">DECLARED</span>
+          <span class="demo-node demo-node--evidence">EVIDENCE</span>
+          <span class="demo-node demo-node--unresolved">UNRESOLVED</span>
         </div>
       </div>
     </header>
 
-    <section class="object-summary">
-      <div class="wrap">
-        <p class="section-index">PUBLIC FIXTURE · NON-CONFIDENTIAL</p>
-        <div class="summary-grid">
-          <article><span>BUNDLE ID</span><strong>rpo-example-minimal-0001</strong></article>
-          <article><span>FORMAT</span><strong>RPO v0.1 · JSON</strong></article>
-          <article><span>STATUS</span><strong class="status-ok">STRUCTURE PRESENT</strong></article>
-          <article><span>DISCLOSURE</span><strong>DEMONSTRATION DATA</strong></article>
+    <section class="demo-section" id="situation">
+      <div class="demo-wrap">
+        <p class="demo-index">01 · THE SITUATION</p>
+        <div class="demo-heading-grid">
+          <h2>FOUR ELEMENTS ARE ENOUGH TO UNDERSTAND THE GAP.</h2>
+          <p>This example is entirely fictional. It shows the RPO logic without exposing a real case.</p>
+        </div>
+        <div class="demo-story-grid">
+          <article class="demo-story-card"><span class="demo-label">01 · EXPECTED</span><h3>Before handover</h3><p>The contract requires the final ventilation test to be completed before the building is handed over.</p></article>
+          <article class="demo-story-card"><span class="demo-label">02 · DECLARED</span><h3>Ready for handover</h3><p>The 15 July meeting minutes state that the building is ready for handover.</p></article>
+          <article class="demo-story-card"><span class="demo-label">03 · SOURCE</span><h3>Test still outstanding</h3><p>The 16 July inspection report states that the final airflow test has not yet been completed.</p></article>
+          <article class="demo-story-card demo-story-card--alert"><span class="demo-label">04 · UNRESOLVED</span><h3>A gap must be addressed</h3><p>The RPO does not automatically decide liability. It preserves the gap, the sources and the question that remains.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="object-inspection">
-      <div class="wrap inspection-grid">
-        <div>
-          <p class="section-index">OBJECT ANATOMY</p>
-          <h2>What the object contains.</h2>
-          <div class="inspection-list">
-            <article><b>01</b><div>
-<h3>Identity</h3>
-<p>Version, stable identifier and creation timestamp.</p>
-</div></article>
-            <article><b>02</b><div>
-<h3>Evidence manifest</h3>
-<p>Declared evidence references and fingerprints.</p>
-</div></article>
-            <article><b>03</b><div>
-<h3>Narrative</h3>
-<p>Structured summary linked to source material.</p>
-</div></article>
-            <article><b>04</b><div>
-<h3>Registry</h3>
-<p>Public entry and integrity fingerprint.</p>
-</div></article>
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">02 · WHY IT MATTERS</p>
+        <h2>THE RPO DOES NOT REPLACE THE WORK. IT PREVENTS THE WORK FROM BECOMING INDEMONSTRABLE.</h2>
+        <div class="demo-value-grid" style="margin-top:42px">
+          <article class="demo-value-card"><span class="demo-label">01 · SAME RECORD</span><h3>One shared representation</h3><p>The teams, auditor, insurer or lawyer can start from the same recorded state rather than reconstructing competing versions later.</p></article>
+          <article class="demo-value-card"><span class="demo-label">02 · NO SILENT REWRITE</span><h3>Every change becomes visible</h3><p>Changing one word, date or source produces a different fingerprint. The earlier state cannot disappear silently.</p></article>
+          <article class="demo-value-card"><span class="demo-label">03 · EARLIER ACTION</span><h3>Correct before conflict</h3><p>The gap can be discussed, checked and corrected while it is still repairable — before audit, mediation or litigation.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">03 · WHAT THE OBJECT PRESERVES</p>
+        <h2>ONE SITUATION, READABLE BY PEOPLE AND STRUCTURED FOR MACHINES.</h2>
+        <div class="demo-anatomy-grid" style="margin-top:42px">
+          <article class="demo-anatomy-card"><span class="demo-label">01 · CONTEXT</span><h3>What is this about?</h3><p>Version, identifier, date, issuer and the subject concerned.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">02 · SOURCES</span><h3>What supports the record?</h3><p>References, descriptions, identifiers and declared fingerprints of the material used.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">03 · REPRESENTATION</span><h3>What can be said now?</h3><p>A structured summary that preserves the unresolved point and does not turn a hypothesis into a fact.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">04 · INTEGRITY</span><h3>Has the file changed?</h3><p>A reproducible digital fingerprint makes two copies of the same object comparable.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">04 · TWO READINGS</p>
+        <div class="demo-heading-grid">
+          <h2>PEOPLE READ THE MEANING. MACHINES READ THE STRUCTURE.</h2>
+          <p>The same object can be presented simply without losing its technical format.</p>
+        </div>
+        <div class="demo-readable-grid">
+          <article class="demo-human-card">
+            <h3>Human view</h3>
+            <div class="demo-human-copy">
+              <p><strong>Human reading.</strong> The building was declared ready while the final ventilation test was still outstanding.</p>
+              <p>The record preserves the contractual requirement, the progress declaration, the inspection report and the question that remains open.</p>
+              <p>It does not automatically state that someone lied or that legal liability has been established.</p>
+            </div>
+          </article>
+          <div>
+            <p class="demo-index">Technical view</p>
+            <div class="demo-tech-summary">
+              <div><span>Version</span><strong data-demo-field="version">—</strong></div>
+              <div><span>Identifier</span><strong data-demo-field="bundle">—</strong></div>
+              <div><span>Subject</span><strong data-demo-field="subject">—</strong></div>
+              <div><span>Referenced sources</span><strong data-demo-field="evidence">—</strong></div>
+            </div>
+            <details class="demo-json-details">
+              <summary>Show the technical JSON</summary>
+              <div class="demo-code-head"><span>rpo.json</span><button type="button" id="copyDemoJson">COPY JSON</button></div>
+              <pre class="demo-json" id="demoJson" aria-live="polite">Loading…</pre>
+            </details>
           </div>
         </div>
-        <div class="code-panel">
-          <div class="code-head">
-<span>rpo.json</span><button type="button" id="copyJson">COPY JSON</button>
-</div>
-          <pre id="exampleJson" aria-live="polite">Loading public fixture…</pre>
-        </div>
       </div>
     </section>
 
-    <section class="essential-boundary">
-      <div class="wrap">
-        <p><strong>Essential boundary.</strong> This example demonstrates form, declared provenance and verifiable integrity. It does not establish the material truth of a case.</p>
+    <section class="demo-boundary">
+      <div class="demo-wrap">
+        <p><strong>Essential boundary.</strong> This example shows how a state is structured and how a change can be detected. It does not prove the material truth of statements, external authenticity of evidence or a legal conclusion.</p>
+        <a class="btn primary" href="/tests.html#laboratory">Test a change yourself</a>
       </div>
     </section>
   </main>
-
-  <footer class="footer rpo-footer"><div class="wrap">
-<div>
-<strong>RPO v0.1</strong><p>Public technical specification maintained by OpenProof.</p>
-</div>
-<div class="footer-links">
-<a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a><a href="/">Specification</a><a href="https://openproof.net">OpenProof</a>
-</div>
-</div></footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script>
-    (() => {
-      const output = document.querySelector('#exampleJson');
-      let raw = '';
-      fetch('https://raw.githubusercontent.com/openproof-net/rpo-spec-v0.1/main/examples/example-minimal/rpo.json')
-        .then(response => response.ok ? response.text() : Promise.reject())
-        .then(text => { raw = text; output.textContent = JSON.stringify(JSON.parse(text), null, 2); })
-        .catch(() => { output.textContent = 'Public fixture unavailable. Open the raw JSON on GitHub.'; });
-      document.querySelector('#copyJson').addEventListener('click', async event => {
-        if (!raw) return;
-        await navigator.clipboard.writeText(raw);
-        event.currentTarget.textContent = 'COPIED';
-        setTimeout(() => event.currentTarget.textContent = 'COPY JSON', 1200);
-      });
-    })();
-  </script>
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>RPO v0.1</strong><p>Public specification maintained by OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/">Specification</a>
+        <a href="/truthx-engine/">TruthX Engine</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-5"></script>
+  <script src="/assets/rpo-demonstration.js?v=20260805-1"></script>
 </body>
 </html>

--- a/docs/examples/public-demo/rpo-en.json
+++ b/docs/examples/public-demo/rpo-en.json
@@ -1,0 +1,52 @@
+{
+  "rpo_version": "0.1",
+  "type": "evidence_bundle",
+  "bundle_id": "9f9af5c8-d359-4da4-8a95-ef909b33747f",
+  "created_at": "2026-08-05T12:00:00Z",
+  "jurisdiction": "Fictional demonstration — no applicable jurisdiction",
+  "language": "en-GB",
+  "issuer": {
+    "name": "OpenProof — public demonstration",
+    "id": "urn:openproof:demo:issuer",
+    "role": "demonstration_issuer"
+  },
+  "subject": {
+    "name": "Project Atlas — ventilation system handover",
+    "id": "urn:openproof:demo:project-atlas",
+    "role": "project"
+  },
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "contract_requirement",
+      "description": "The contract requires a final ventilation test before handover.",
+      "hash": "sha256:a16b27f6220a5d98a38dbf80027949509f7148507da8b77a62b36424d3324b02",
+      "uri": "urn:openproof:demo:atlas:requirement"
+    },
+    {
+      "id": "ev-002",
+      "type": "progress_declaration",
+      "description": "The 15 July meeting minutes declare the building ready for handover.",
+      "hash": "sha256:e4c971510492d2ded5ac50257db393880eb1f5f638cb2cad0a55a970566a0b5f",
+      "uri": "urn:openproof:demo:atlas:minutes"
+    },
+    {
+      "id": "ev-003",
+      "type": "inspection_report",
+      "description": "The 16 July inspection report states that the final airflow test is still outstanding.",
+      "hash": "sha256:4b0fa8b5488385adba81fcc9538d90e3af9e316b37dfe831d791f6a0b1cc56fe",
+      "uri": "urn:openproof:demo:atlas:inspection"
+    }
+  ],
+  "narrative": {
+    "summary": "The building was declared ready for handover while the final ventilation test was still outstanding. The RPO preserves the requirement, the declaration, the inspection finding and the unresolved point without automatically deciding liability.",
+    "pdf_hash": "sha256:demo-public-no-pdf",
+    "timeline_ref": "ev-003"
+  },
+  "registry": {
+    "registry_id": "openproof-public-demo",
+    "entry_id": "demo-atlas-en-0001",
+    "public_hash": "sha256:reference-computed-locally-by-the-demo"
+  },
+  "signatures": []
+}

--- a/docs/examples/public-demo/rpo-fr.json
+++ b/docs/examples/public-demo/rpo-fr.json
@@ -1,0 +1,52 @@
+{
+  "rpo_version": "0.1",
+  "type": "evidence_bundle",
+  "bundle_id": "2d17e9b1-b615-4a47-a452-b2ec8ea11c63",
+  "created_at": "2026-08-05T12:00:00Z",
+  "jurisdiction": "Démonstration fictive — aucune juridiction applicable",
+  "language": "fr-FR",
+  "issuer": {
+    "name": "OpenProof — démonstration publique",
+    "id": "urn:openproof:demo:issuer",
+    "role": "demonstration_issuer"
+  },
+  "subject": {
+    "name": "Projet Atlas — réception d’un système de ventilation",
+    "id": "urn:openproof:demo:project-atlas",
+    "role": "project"
+  },
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "contract_requirement",
+      "description": "Le contrat impose un test final de ventilation avant la réception.",
+      "hash": "sha256:5ed14741ae1fc28e3e297d57b2d037ed1da1d338c55061f6baa09fadbfd5730d",
+      "uri": "urn:openproof:demo:atlas:requirement"
+    },
+    {
+      "id": "ev-002",
+      "type": "progress_declaration",
+      "description": "Le compte rendu du 15 juillet déclare le bâtiment prêt à être réceptionné.",
+      "hash": "sha256:5983f3859b0234723a4661dfb350801ed52eacdbf116c2ad5235b79a9a3f48ea",
+      "uri": "urn:openproof:demo:atlas:minutes"
+    },
+    {
+      "id": "ev-003",
+      "type": "inspection_report",
+      "description": "Le rapport d’inspection du 16 juillet indique que le test final de débit d’air reste à réaliser.",
+      "hash": "sha256:66e7d65d48891a1ee5866c44d73d4bd3009bf5804d8efd0f25f4971803664d6c",
+      "uri": "urn:openproof:demo:atlas:inspection"
+    }
+  ],
+  "narrative": {
+    "summary": "Le bâtiment a été déclaré prêt à être réceptionné alors que le test final de ventilation restait à réaliser. Le RPO conserve l’exigence, la déclaration, le constat d’inspection et le point non résolu, sans décider automatiquement d’une responsabilité.",
+    "pdf_hash": "sha256:demo-public-no-pdf",
+    "timeline_ref": "ev-003"
+  },
+  "registry": {
+    "registry_id": "openproof-public-demo",
+    "entry_id": "demo-atlas-fr-0001",
+    "public_hash": "sha256:reference-computed-locally-by-the-demo"
+  },
+  "signatures": []
+}

--- a/docs/fr/examples.html
+++ b/docs/fr/examples.html
@@ -4,56 +4,51 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>Exemple de RPO : manifeste de preuves et empreinte SHA-256 | OpenProof</title>
-  <meta name="description" content="Examinez un exemple public de RPO : noyau scellé, manifeste de preuves, provenance, réserves explicites et empreinte d’intégrité SHA-256.">
+  <title>Voir un RPO en langage humain | OpenProof</title>
+  <meta name="description" content="Comprenez concrètement ce qu’un Registered Probative Object conserve : situation, sources, contradiction, point non résolu et empreinte d’intégrité.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/fr/examples.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/examples.html">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/examples.html">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/examples.html">
-<meta property="og:type" content="article">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/examples.html">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/examples.html">
+  <meta property="og:type" content="article">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="Exemple de RPO : manifeste de preuves et empreinte SHA-256">
-  <meta property="og:description" content="Examinez un exemple public de RPO : noyau scellé, manifeste de preuves, provenance, réserves explicites et empreinte d’intégrité SHA-256.">
+  <meta property="og:title" content="Un RPO expliqué en langage humain">
+  <meta property="og:description" content="Comprenez concrètement ce qu’un Registered Probative Object conserve : situation, sources, contradiction, point non résolu et empreinte d’intégrité.">
   <meta property="og:url" content="https://rpo.openproof.net/fr/examples.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:locale:alternate" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Exemple de RPO : manifeste de preuves et empreinte SHA-256">
-  <meta name="twitter:description" content="Examinez un exemple public de RPO : noyau scellé, manifeste de preuves, provenance, réserves explicites et empreinte d’intégrité SHA-256.">
+  <meta name="twitter:title" content="Un RPO expliqué en langage humain">
+  <meta name="twitter:description" content="Comprenez concrètement ce qu’un Registered Probative Object conserve : situation, sources, contradiction, point non résolu et empreinte d’intégrité.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@type": "TechArticle",
-  "headline": "Exemple public de Registered Probative Object (RPO)",
-  "description": "Exemple minimal de RPO contenant un noyau scellé, un manifeste de preuves, des réserves et une empreinte publique d’intégrité SHA-256.",
-  "url": "https://rpo.openproof.net/fr/examples.html",
-  "author": {
-    "@type": "Organization",
-    "name": "OpenProof",
-    "url": "https://openproof.net"
-  },
-  "isPartOf": {
-    "@id": "https://rpo.openproof.net/fr/#website"
-  },
-  "about": [
-    "Registered Probative Object",
-    "evidence manifest",
-    "evidence provenance",
-    "SHA-256"
-  ],
-  "inLanguage": "fr"
-}
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "name": "Démonstration publique d’un Registered Probative Object",
+    "headline": "Démonstration publique d’un Registered Probative Object",
+    "url": "https://rpo.openproof.net/fr/examples.html",
+    "description": "Comprenez concrètement ce qu’un Registered Probative Object conserve : situation, sources, contradiction, point non résolu et empreinte d’intégrité.",
+    "version": "0.1",
+    "isAccessibleForFree": true,
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "inLanguage": "fr"
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="fr_FR">
-<meta property="og:locale:alternate" content="en_US">
+  <link rel="stylesheet" href="/assets/rpo-demonstration.css?v=20260805-1">
 </head>
-<body class="rpo-home rpo-subpage">
+<body class="rpo-home rpo-subpage rpo-demo-page" data-rpo-demo-page data-demo-src="/examples/public-demo/rpo-fr.json">
   <a class="skip" href="#main">Aller au contenu</a>
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
@@ -61,108 +56,142 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
       <div class="links">
-        <a href="/fr/">Spécification</a><a href="/fr/examples.html" aria-current="page">Exemple</a><a href="/fr/tests.html">Vérifier</a><a href="/fr/gersende-de-parcey.html">Fondatrice</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/fr/">Spécification</a>
+        <a href="/fr/examples.html" aria-current="page">Voir un RPO</a>
+        <a href="/fr/tests.html">Vérifier un RPO</a>
+        <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Langue">
-<a href="/fr/examples.html" lang="fr" hreflang="fr" aria-current="page">FR</a><span aria-hidden="true">|</span><a href="/examples.html" lang="en" hreflang="en">EN</a>
-</div>
+        <a href="/fr/examples.html" lang="fr" hreflang="fr" aria-current="page">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/examples.html" lang="en" hreflang="en">EN</a>
+      </div>
     </div>
   </nav>
 
   <main id="main">
-    <header class="sub-hero cosmos">
+    <header class="demo-hero cosmos">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap">
-        <p class="eyebrow">02 · EXEMPLE · RPO V0.1</p>
-        <h1>
-          <span>Un RPO, rendu lisible.</span>
-          </h1>
-        <p class="sub-lead">Un objet minimal permet d’inspecter la structure publique sans exposer de dossier réel. Le même fichier peut être lu par une personne, une machine et l’outil de vérification.</p>
-        <div class="sub-actions">
-          <a class="btn primary" href="/fr/tests.html">Vérifier cet objet</a>
-          <a class="btn" href="https://github.com/openproof-net/rpo-spec-v0.1/blob/main/examples/example-minimal/rpo.json">Raw JSON ↗</a>
+      <div class="demo-wrap">
+        <div class="demo-hero-copy">
+          <p class="demo-kicker">02 · VOIR UN RPO · DONNÉES FICTIVES</p>
+          <h1>QUE MONTRE CONCRÈTEMENT UN RPO ?<span>COMMENÇONS PAR LA SITUATION, PAS PAR LE CODE.</span></h1>
+          <p class="demo-hero-lead">Un RPO n’est ni « la vérité », ni une conclusion juridique. C’est un dossier structuré qui conserve ce qui était attendu, ce qui a été déclaré, ce que les sources montrent et ce qui reste non résolu.</p>
+          <div class="demo-actions">
+            <a class="btn primary" href="#situation">Lire la situation</a>
+            <a class="btn" href="/fr/tests.html#laboratory">Vérifier cette copie</a>
+          </div>
+          <p class="demo-one-line">En une phrase : le RPO garde ensemble la situation, les sources, les limites et l’empreinte qui permet de détecter toute modification.</p>
+        </div>
+        <div class="demo-visual" aria-label="Démonstration RPO">
+          <div class="demo-visual-ring demo-visual-ring--outer"></div>
+          <div class="demo-visual-ring demo-visual-ring--inner"></div>
+          <div class="demo-visual-core"><div><strong>RPO</strong><span>ÉTAT VÉRIFIABLE</span></div></div>
+          <span class="demo-node demo-node--expected">ATTENDU</span>
+          <span class="demo-node demo-node--declared">DÉCLARÉ</span>
+          <span class="demo-node demo-node--evidence">SOURCE</span>
+          <span class="demo-node demo-node--unresolved">NON RÉSOLU</span>
         </div>
       </div>
     </header>
 
-    <section class="object-summary">
-      <div class="wrap">
-        <p class="section-index">JEU D’ESSAI PUBLIC · NON CONFIDENTIEL</p>
-        <div class="summary-grid">
-          <article><span>ID DU BUNDLE</span><strong>rpo-example-minimal-0001</strong></article>
-          <article><span>FORMAT</span><strong>RPO v0.1 · JSON</strong></article>
-          <article><span>STATUT</span><strong class="status-ok">STRUCTURE PRÉSENTE</strong></article>
-          <article><span>DONNÉES</span><strong>DONNÉES DE DÉMONSTRATION</strong></article>
+    <section class="demo-section" id="situation">
+      <div class="demo-wrap">
+        <p class="demo-index">01 · LA SITUATION</p>
+        <div class="demo-heading-grid">
+          <h2>QUATRE ÉLÉMENTS SUFFISENT POUR COMPRENDRE L’ÉCART.</h2>
+          <p>Cet exemple est entièrement fictif. Il montre la logique du RPO sans exposer de dossier réel.</p>
+        </div>
+        <div class="demo-story-grid">
+          <article class="demo-story-card"><span class="demo-label">01 · ATTENDU</span><h3>Avant la réception</h3><p>Le contrat exige que le test final de ventilation soit terminé avant la réception du bâtiment.</p></article>
+          <article class="demo-story-card"><span class="demo-label">02 · DÉCLARÉ</span><h3>Prêt à être réceptionné</h3><p>Le compte rendu du 15 juillet indique que le bâtiment est prêt à être réceptionné.</p></article>
+          <article class="demo-story-card"><span class="demo-label">03 · SOURCE</span><h3>Test encore manquant</h3><p>Le rapport d’inspection du 16 juillet précise que le test final de débit d’air reste à effectuer.</p></article>
+          <article class="demo-story-card demo-story-card--alert"><span class="demo-label">04 · NON RÉSOLU</span><h3>Un écart doit être traité</h3><p>Le RPO ne décide pas automatiquement qui est responsable. Il conserve l’écart, les sources et la question à résoudre.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="object-inspection">
-      <div class="wrap inspection-grid">
-        <div>
-          <p class="section-index">ANATOMIE DE L’OBJET</p>
-          <h2>Ce que contient l’objet.</h2>
-          <div class="inspection-list">
-            <article><b>01</b><div>
-<h3>Identité</h3>
-<p>Version, identifiant stable et horodatage de création.</p>
-</div></article>
-            <article><b>02</b><div>
-<h3>Manifeste de preuves</h3>
-<p>Références aux pièces et empreintes déclarées.</p>
-</div></article>
-            <article><b>03</b><div>
-<h3>Récit</h3>
-<p>Résumé structuré relié aux éléments sources.</p>
-</div></article>
-            <article><b>04</b><div>
-<h3>Registre</h3>
-<p>Entrée publique et empreinte d’intégrité.</p>
-</div></article>
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">02 · POURQUOI C’EST UTILE</p>
+        <h2>LE RPO NE REMPLACE PAS LE TRAVAIL. IL EMPÊCHE QUE LE TRAVAIL DEVIENNE INDÉMONTRABLE.</h2>
+        <div class="demo-value-grid" style="margin-top:42px">
+          <article class="demo-value-card"><span class="demo-label">01 · MÊME DOSSIER</span><h3>Une représentation commune</h3><p>Les personnes, l’auditeur, l’assureur ou l’avocat peuvent repartir du même état enregistré plutôt que de versions reconstruites plus tard.</p></article>
+          <article class="demo-value-card"><span class="demo-label">02 · PAS DE RÉÉCRITURE</span><h3>Toute modification devient visible</h3><p>Changer un mot, une date ou une pièce produit une empreinte différente. L’état antérieur ne disparaît pas silencieusement.</p></article>
+          <article class="demo-value-card"><span class="demo-label">03 · PLUS TÔT</span><h3>Corriger avant le conflit</h3><p>L’écart peut être discuté, vérifié et corrigé pendant qu’il est encore réparable — avant l’audit, la médiation ou le contentieux.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">03 · CE QUE L’OBJET CONSERVE</p>
+        <h2>UNE SITUATION LISIBLE PAR L’HUMAIN ET STRUCTURÉE POUR LA MACHINE.</h2>
+        <div class="demo-anatomy-grid" style="margin-top:42px">
+          <article class="demo-anatomy-card"><span class="demo-label">01 · CONTEXTE</span><h3>De quoi parle-t-on ?</h3><p>Version, identifiant, date, émetteur et objet concerné.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">02 · SOURCES</span><h3>Sur quoi repose le dossier ?</h3><p>Références, descriptions, identifiants et empreintes déclarées des éléments utilisés.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">03 · REPRÉSENTATION</span><h3>Que peut-on dire à ce stade ?</h3><p>Un résumé structuré qui conserve aussi le point non résolu et ne transforme pas une hypothèse en fait.</p></article>
+          <article class="demo-anatomy-card"><span class="demo-label">04 · INTÉGRITÉ</span><h3>Le fichier a-t-il changé ?</h3><p>Une empreinte numérique reproductible permet de comparer deux copies du même objet.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">04 · DEUX LECTURES</p>
+        <div class="demo-heading-grid">
+          <h2>LA PERSONNE LIT LE SENS. LA MACHINE LIT LA STRUCTURE.</h2>
+          <p>Le même objet peut être présenté simplement sans perdre son format technique.</p>
+        </div>
+        <div class="demo-readable-grid">
+          <article class="demo-human-card">
+            <h3>Vue humaine</h3>
+            <div class="demo-human-copy">
+              <p><strong>Lecture humaine.</strong> Le bâtiment a été déclaré prêt alors que le test final de ventilation restait à réaliser.</p>
+              <p>Le dossier conserve l’exigence contractuelle, la déclaration d’avancement, le rapport d’inspection et la question encore ouverte.</p>
+              <p>Il n’affirme pas automatiquement qu’une personne a menti ni qu’une responsabilité juridique est établie.</p>
+            </div>
+          </article>
+          <div>
+            <p class="demo-index">Vue technique</p>
+            <div class="demo-tech-summary">
+              <div><span>Version</span><strong data-demo-field="version">—</strong></div>
+              <div><span>Identifiant</span><strong data-demo-field="bundle">—</strong></div>
+              <div><span>Objet</span><strong data-demo-field="subject">—</strong></div>
+              <div><span>Sources référencées</span><strong data-demo-field="evidence">—</strong></div>
+            </div>
+            <details class="demo-json-details">
+              <summary>Afficher le JSON technique</summary>
+              <div class="demo-code-head"><span>rpo.json</span><button type="button" id="copyDemoJson">COPIER LE JSON</button></div>
+              <pre class="demo-json" id="demoJson" aria-live="polite">Chargement…</pre>
+            </details>
           </div>
         </div>
-        <div class="code-panel">
-          <div class="code-head">
-<span>rpo.json</span><button type="button" id="copyJson">COPIER LE JSON</button>
-</div>
-          <pre id="exampleJson" aria-live="polite">Chargement du jeu d’essai public…</pre>
-        </div>
       </div>
     </section>
 
-    <section class="essential-boundary">
-      <div class="wrap">
-        <p><strong>Limite essentielle.</strong> Cet exemple démontre une forme, une provenance déclarée et une intégrité vérifiable. Il ne démontre pas la vérité matérielle du contenu d’un dossier.</p>
-        </div>
+    <section class="demo-boundary">
+      <div class="demo-wrap">
+        <p><strong>Limite essentielle.</strong> Cet exemple montre comment un état est structuré et comment une modification peut être détectée. Il ne prouve ni la vérité matérielle des déclarations, ni l’authenticité externe des pièces, ni une conclusion juridique.</p>
+        <a class="btn primary" href="/fr/tests.html#laboratory">Tester la modification vous-même</a>
+      </div>
     </section>
   </main>
-
-  <footer class="footer rpo-footer"><div class="wrap">
-<div>
-<strong>RPO v0.1</strong><p>Spécification technique publique maintenue par OpenProof.</p>
-</div>
-<div class="footer-links">
-<a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a><a href="/fr/">Spécification</a><a href="https://openproof.net">OpenProof</a>
-</div>
-</div></footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script>
-    (() => {
-      const output = document.querySelector('#exampleJson');
-      let raw = '';
-      fetch('https://raw.githubusercontent.com/openproof-net/rpo-spec-v0.1/main/examples/example-minimal/rpo.json')
-        .then(response => response.ok ? response.text() : Promise.reject())
-        .then(text => { raw = text; output.textContent = JSON.stringify(JSON.parse(text), null, 2); })
-        .catch(() => { output.textContent = 'Jeu d’essai indisponible. Ouvrez le JSON brut sur GitHub.'; });
-      document.querySelector('#copyJson').addEventListener('click', async event => {
-        if (!raw) return;
-        await navigator.clipboard.writeText(raw);
-        event.currentTarget.textContent = 'COPIÉ';
-        setTimeout(() => event.currentTarget.textContent = 'COPIER LE JSON', 1200);
-      });
-    })();
-  </script>
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>RPO v0.1</strong><p>Spécification publique maintenue par OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/fr/">Spécification</a>
+        <a href="/fr/truthx-engine/">TruthX Engine</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-5"></script>
+  <script src="/assets/rpo-demonstration.js?v=20260805-1"></script>
 </body>
 </html>

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -9,9 +9,9 @@
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/fr/">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
-<meta property="og:type" content="website">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
+  <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
   <meta property="og:title" content="Registered Probative Object (RPO) — Spécification publique">
   <meta property="og:description" content="Spécification publique du Registered Probative Object (RPO) : noyau scellé, provenance des preuves, réserves explicites et intégrité SHA-256 vérifiable indépendamment.">
@@ -23,41 +23,39 @@
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "WebSite",
-      "@id": "https://rpo.openproof.net/fr/#website",
-      "url": "https://rpo.openproof.net/fr/",
-      "name": "RPO — Spécification publique",
-      "publisher": {
-        "@id": "https://openproof.net/#organization"
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://rpo.openproof.net/fr/#website",
+        "url": "https://rpo.openproof.net/fr/",
+        "name": "RPO — Spécification publique",
+        "publisher": { "@id": "https://openproof.net/#organization" },
+        "inLanguage": "fr"
       },
-      "inLanguage": "fr"
-    },
-    {
-      "@type": "TechArticle",
-      "@id": "https://rpo.openproof.net/fr/#specification",
-      "headline": "Registered Probative Object (RPO) — Spécification publique v0.1",
-      "description": "Spécification publique d’un objet probatoire stable, traçable et vérifiable indépendamment.",
-      "url": "https://rpo.openproof.net/fr/",
-      "author": {
-        "@type": "Organization",
-        "name": "OpenProof",
-        "url": "https://openproof.net"
-      },
-      "about": [
-        "Registered Probative Object",
-        "evidence provenance",
-        "canonical JSON",
-        "SHA-256 integrity",
-        "probative infrastructure"
-      ],
-      "version": "0.1",
-      "inLanguage": "fr"
-    }
-  ]
-}
+      {
+        "@type": "TechArticle",
+        "@id": "https://rpo.openproof.net/fr/#specification",
+        "headline": "Registered Probative Object (RPO) — Spécification publique v0.1",
+        "description": "Spécification publique d’un objet probatoire stable, traçable et vérifiable indépendamment.",
+        "url": "https://rpo.openproof.net/fr/",
+        "author": {
+          "@type": "Organization",
+          "name": "OpenProof",
+          "url": "https://openproof.net"
+        },
+        "about": [
+          "Registered Probative Object",
+          "evidence provenance",
+          "canonical JSON",
+          "SHA-256 integrity",
+          "probative infrastructure"
+        ],
+        "version": "0.1",
+        "inLanguage": "fr"
+      }
+    ]
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
@@ -65,8 +63,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="fr_FR">
-<meta property="og:locale:alternate" content="en_US">
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:locale:alternate" content="en_US">
 </head>
 <body class="rpo-home">
   <a class="skip" href="#main">Aller au contenu</a>
@@ -77,13 +75,19 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
       <div class="links">
-        <a href="/fr/" aria-current="page">Spécification</a><a href="/fr/examples.html">Exemple</a><a href="/fr/tests.html">Vérifier</a><a href="/fr/gersende-de-parcey.html">Fondatrice</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/fr/" aria-current="page">Spécification</a>
+        <a href="/fr/examples.html">Voir un RPO</a>
+        <a href="/fr/tests.html">Vérifier un RPO</a>
+        <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Langue">
-<a href="/fr/" lang="fr" hreflang="fr" aria-current="page">FR</a><span aria-hidden="true">|</span><a href="/" lang="en" hreflang="en">EN</a>
-</div>
+        <a href="/fr/" lang="fr" hreflang="fr" aria-current="page">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/" lang="en" hreflang="en">EN</a>
+      </div>
     </div>
   </nav>
 
@@ -93,21 +97,13 @@
       <div class="wrap rpo-hero-grid">
         <div class="rpo-copy">
           <p class="eyebrow">OPENPROOF · NORME PUBLIQUE · V0.1</p>
-          <h1>
-            <span>Un objet probatoire.<br>Stable. Vérifiable. Défendable.</span>
-            </h1>
-          <p class="rpo-lead">
-            <span>Le RPO est le format public produit par OpenProof pour préserver un dossier structuré, ses sources, ses réserves et son intégrité — sans confondre vérification et vérité.</span>
-            </p>
+          <h1><span>Un objet probatoire.<br>Stable. Vérifiable. Défendable.</span></h1>
+          <p class="rpo-lead"><span>Le RPO est le format public produit par OpenProof pour préserver un dossier structuré, ses sources, ses réserves et son intégrité — sans confondre vérification et vérité.</span></p>
           <div class="rpo-actions">
-            <a class="btn primary" href="/fr/">
-              <span>Lire la spécification</span>
-              </a>
-            <a class="btn" href="/fr/examples.html">
-              <span>Voir un RPO</span>
-              </a>
+            <a class="btn primary" href="#definition-title"><span>Comprendre le RPO</span></a>
+            <a class="btn" href="/fr/examples.html"><span>Voir un RPO</span></a>
           </div>
-          <p class="version-line">RPO v0.1 · JSON · SHA-256 · deterministic verification</p>
+          <p class="version-line">RPO v0.1 · JSON · SHA-256 · vérification déterministe</p>
         </div>
 
         <div class="rpo-object" aria-label="Registered Probative Object">
@@ -119,18 +115,10 @@
             <strong>RPO</strong>
             <span>REGISTERED<br>PROBATIVE OBJECT</span>
           </div>
-          <div class="rpo-signal signal-source">
-<i></i><span>SOURCES</span>
-</div>
-          <div class="rpo-signal signal-structure">
-<i></i><span>STRUCTURE</span>
-</div>
-          <div class="rpo-signal signal-reserve">
-<i></i><span>RESERVATIONS</span>
-</div>
-          <div class="rpo-signal signal-hash">
-<i></i><span>INTEGRITY HASH</span>
-</div>
+          <div class="rpo-signal signal-source"><i></i><span>SOURCES</span></div>
+          <div class="rpo-signal signal-structure"><i></i><span>STRUCTURE</span></div>
+          <div class="rpo-signal signal-reserve"><i></i><span>RÉSERVES</span></div>
+          <div class="rpo-signal signal-hash"><i></i><span>EMPREINTE</span></div>
         </div>
       </div>
     </header>
@@ -139,14 +127,10 @@
       <div class="wrap">
         <p class="section-index">01 · DÉFINITION</p>
         <div class="definition-grid">
-          <h2 id="definition-title">
-            <span>Ce que le RPO garantit.<br>Et ce qu’il ne prétend pas garantir.</span>
-            </h2>
+          <h2 id="definition-title"><span>Ce que le RPO garantit.<br>Et ce qu’il ne prétend pas garantir.</span></h2>
           <div class="definition-copy">
             <p>Un RPO rend détectable toute modification du noyau scellé. Il conserve la provenance, les transformations et les réserves nécessaires à un examen indépendant.</p>
-            <p class="boundary">
-              <span><strong>Limite essentielle :</strong> l’intégrité d’un objet ne prouve pas la vérité de son contenu. OpenProof structure et rend vérifiable ; il ne juge pas.</span>
-              </p>
+            <p class="boundary"><span><strong>Limite essentielle :</strong> l’intégrité d’un objet ne prouve pas la vérité de son contenu. OpenProof structure et rend vérifiable ; il ne juge pas.</span></p>
           </div>
         </div>
       </div>
@@ -155,26 +139,12 @@
     <section class="rpo-anatomy" aria-labelledby="anatomy-title">
       <div class="wrap">
         <p class="section-index">02 · ANATOMIE</p>
-        <h2 id="anatomy-title">
-          <span>Quatre éléments. Une trace reproductible.</span>
-          </h2>
+        <h2 id="anatomy-title"><span>Quatre éléments. Une trace reproductible.</span></h2>
         <div class="anatomy-grid">
-          <article>
-            <span>01</span><h3>Sealed core</h3>
-            <p>Le noyau JSON canonique du dossier.</p>
-            </article>
-          <article>
-            <span>02</span><h3>Manifeste de preuves</h3>
-            <p>Les sources, leurs identifiants et leur provenance.</p>
-            </article>
-          <article>
-            <span>03</span><h3>Reservations</h3>
-            <p>Les lacunes, contradictions et limites explicites.</p>
-            </article>
-          <article>
-            <span>04</span><h3>Public hash</h3>
-            <p>L’empreinte SHA-256 permettant de détecter l’altération.</p>
-            </article>
+          <article><span>01</span><h3>Noyau scellé</h3><p>Le noyau JSON canonique du dossier.</p></article>
+          <article><span>02</span><h3>Manifeste de preuves</h3><p>Les sources, leurs identifiants et leur provenance.</p></article>
+          <article><span>03</span><h3>Réserves</h3><p>Les lacunes, contradictions et limites explicites.</p></article>
+          <article><span>04</span><h3>Empreinte publique</h3><p>L’empreinte SHA-256 permettant de détecter l’altération.</p></article>
         </div>
       </div>
     </section>
@@ -182,27 +152,25 @@
     <section class="rpo-paths" aria-labelledby="paths-title">
       <div class="wrap">
         <p class="section-index">03 · ACCÈS PUBLIC</p>
-        <h2 id="paths-title">
-          <span>Trois accès. Rien de plus.</span>
-          </h2>
+        <h2 id="paths-title"><span>Comprendre. Voir. Vérifier.</span></h2>
         <div class="path-grid">
-          <a href="/fr/">
-            <span>SPÉCIFICATION</span><strong>01</strong>
-            <h3>Comprendre le format</h3>
-            <p>Schéma, sérialisation canonique, empreinte et conformité.</p>
-            <i>Ouvrir la spécification →</i>
+          <a href="#definition-title">
+            <span>COMPRENDRE</span><strong>01</strong>
+            <h3>Comprendre le RPO</h3>
+            <p>Ce que le format conserve, garantit et refuse volontairement de décider.</p>
+            <i>Lire la spécification publique →</i>
           </a>
           <a href="/fr/examples.html">
-            <span>EXEMPLE</span><strong>02</strong>
-            <h3>Inspectioner un objet</h3>
-            <p>Un bundle d’exemple lisible par l’humain et la machine.</p>
-            <i>Ouvrir l’exemple →</i>
+            <span>VOIR</span><strong>02</strong>
+            <h3>Suivre une situation fictive</h3>
+            <p>Comprendre l’écart en langage humain avant d’ouvrir le JSON technique.</p>
+            <i>Voir un RPO →</i>
           </a>
           <a href="/fr/tests.html">
             <span>VÉRIFIER</span><strong>03</strong>
-            <h3>Reproduire la vérification</h3>
-            <p>Vecteurs de test et résultat attendu, indépendamment d’OpenProof.</p>
-            <i>Ouvrir la vérification →</i>
+            <h3>Détecter une modification</h3>
+            <p>Changer un détail et voir immédiatement l’empreinte SHA-256 locale changer.</p>
+            <i>Vérifier un RPO →</i>
           </a>
         </div>
       </div>
@@ -210,35 +178,26 @@
 
     <section class="architecture-line" aria-label="Architecture de marque">
       <div class="wrap">
-        <div>
-<span>OPENPROOF</span><strong>Infrastructure probatoire</strong>
-</div>
+        <div><span>OPENPROOF</span><strong>Infrastructure probatoire</strong></div>
         <b aria-hidden="true">→</b>
-        <div>
-<span>TRUTHX ENGINE</span><strong>Moteur de structuration déterministe</strong>
-</div>
+        <div><span>TRUTHX ENGINE</span><strong>Moteur de structuration déterministe</strong></div>
         <b aria-hidden="true">→</b>
-        <div>
-<span>RPO</span><strong>Objet probatoire enregistré</strong>
-</div>
+        <div><span>RPO</span><strong>Objet probatoire enregistré</strong></div>
       </div>
     </section>
   </main>
 
   <footer class="footer rpo-footer">
     <div class="wrap">
-      <div>
-        <strong>RPO v0.1</strong>
-        <p>Spécification technique publique maintenue par OpenProof.</p>
-      </div>
+      <div><strong>RPO v0.1</strong><p>Spécification technique publique maintenue par OpenProof.</p></div>
       <div class="footer-links">
         <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
         <a href="/fr/">Spécification</a>
         <a href="https://openproof.net">OpenProof</a>
-        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende Ryard de Parcey on LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
+        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende Ryard de Parcey sur LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
       </div>
     </div>
   </footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
+  <script src="/assets/openproof-v2.js?v=20260805-6"></script>
 </body>
 </html>

--- a/docs/fr/tests.html
+++ b/docs/fr/tests.html
@@ -4,50 +4,52 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>Vérifier un RPO : JSON canonique et empreinte SHA-256 | OpenProof</title>
-  <meta name="description" content="Vérifiez localement un Registered Probative Object : structure requise, sérialisation JSON canonique déterministe et empreinte d’intégrité SHA-256 reproductible.">
+  <title>Vérifier un RPO sans faire confiance à OpenProof | OpenProof</title>
+  <meta name="description" content="Chargez une copie publique, calculez son empreinte dans votre navigateur, modifiez un détail et observez immédiatement la différence.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/fr/tests.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/tests.html">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/tests.html">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/tests.html">
-<meta property="og:type" content="website">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/tests.html">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/tests.html">
+  <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="Vérifier un RPO : JSON canonique et empreinte SHA-256">
-  <meta property="og:description" content="Vérifiez localement un Registered Probative Object : structure requise, sérialisation JSON canonique déterministe et empreinte d’intégrité SHA-256 reproductible.">
+  <meta property="og:title" content="Détecter si un RPO a été modifié">
+  <meta property="og:description" content="Chargez une copie publique, calculez son empreinte dans votre navigateur, modifiez un détail et observez immédiatement la différence.">
   <meta property="og:url" content="https://rpo.openproof.net/fr/tests.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:locale:alternate" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Vérifier un RPO : JSON canonique et empreinte SHA-256">
-  <meta name="twitter:description" content="Vérifiez localement un Registered Probative Object : structure requise, sérialisation JSON canonique déterministe et empreinte d’intégrité SHA-256 reproductible.">
+  <meta name="twitter:title" content="Détecter si un RPO a été modifié">
+  <meta name="twitter:description" content="Chargez une copie publique, calculez son empreinte dans votre navigateur, modifiez un détail et observez immédiatement la différence.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Outil de vérification RPO",
-  "applicationCategory": "DeveloperApplication",
-  "operatingSystem": "Tout navigateur web moderne",
-  "url": "https://rpo.openproof.net/fr/tests.html",
-  "description": "Vérification locale de la structure d’un Registered Probative Object, de sa sérialisation JSON canonique et de son intégrité SHA-256.",
-  "isAccessibleForFree": true,
-  "publisher": {
-    "@type": "Organization",
-    "name": "OpenProof",
-    "url": "https://openproof.net"
-  },
-  "inLanguage": "fr"
-}
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Outil pédagogique de vérification RPO",
+    "headline": "Outil pédagogique de vérification RPO",
+    "url": "https://rpo.openproof.net/fr/tests.html",
+    "description": "Chargez une copie publique, calculez son empreinte dans votre navigateur, modifiez un détail et observez immédiatement la différence.",
+    "applicationCategory": "EducationalApplication",
+    "isAccessibleForFree": true,
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "inLanguage": "fr"
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="fr_FR">
-<meta property="og:locale:alternate" content="en_US">
+  <link rel="stylesheet" href="/assets/rpo-demonstration.css?v=20260805-1">
+  <link rel="stylesheet" href="/assets/rpo-demonstration-copy.css?v=20260805-1">
 </head>
-<body class="rpo-home rpo-subpage">
+<body class="rpo-home rpo-subpage rpo-verify-page" data-rpo-demo-page data-demo-src="/examples/public-demo/rpo-fr.json">
   <a class="skip" href="#main">Aller au contenu</a>
   <nav class="nav" aria-label="Navigation principale">
     <div class="wrap navin">
@@ -55,143 +57,123 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>SPÉCIFICATION PUBLIQUE RPO</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Ouvrir le menu">Menu</button>
       <div class="links">
-        <a href="/fr/">Spécification</a><a href="/fr/examples.html">Exemple</a><a href="/fr/tests.html" aria-current="page">Vérifier</a><a href="/fr/gersende-de-parcey.html">Fondatrice</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/fr/">Spécification</a>
+        <a href="/fr/examples.html">Voir un RPO</a>
+        <a href="/fr/tests.html" aria-current="page">Vérifier un RPO</a>
+        <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Langue">
-<a href="/fr/tests.html" lang="fr" hreflang="fr" aria-current="page">FR</a><span aria-hidden="true">|</span><a href="/tests.html" lang="en" hreflang="en">EN</a>
-</div>
+        <a href="/fr/tests.html" lang="fr" hreflang="fr" aria-current="page">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/tests.html" lang="en" hreflang="en">EN</a>
+      </div>
     </div>
   </nav>
 
   <main id="main">
-    <header class="sub-hero cosmos">
+    <header class="demo-hero cosmos">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap">
-        <p class="eyebrow">03 · VÉRIFIER · EXÉCUTION LOCALE</p>
-        <h1>
-          <span>Vérifier, sans nous croire.</span>
-          </h1>
-        <p class="sub-lead">Le contrôle s’exécute dans votre navigateur. Aucun objet n’est envoyé à OpenProof : la structure est inspectée, le JSON est sérialisé de manière déterministe, puis son empreinte SHA-256 est calculée localement.</p>
+      <div class="demo-wrap">
+        <div class="demo-hero-copy">
+          <p class="demo-kicker">03 · VÉRIFIER UN RPO · EXÉCUTION LOCALE</p>
+          <h1>PEUT-ON DÉTECTER SI CE RPO A CHANGÉ ?<span>OUI. MODIFIEZ UN MOT : L’EMPREINTE CHANGE.</span></h1>
+          <p class="demo-hero-lead">Cette page charge la copie publique de démonstration, calcule son empreinte dans votre navigateur et la compare à la copie de référence. Aucun fichier n’est envoyé à OpenProof.</p>
+          <div class="demo-actions">
+            <a class="btn primary" href="#laboratory">Lancer la démonstration</a>
+            <a class="btn" href="/fr/examples.html">Revoir l’exemple</a>
+          </div>
+          <p class="demo-one-line">Vous n’avez pas besoin de comprendre le JSON : cliquez sur « Simuler une modification », puis observez le résultat changer.</p>
         </div>
+        <div class="demo-visual" aria-label="Comparaison d’empreintes RPO">
+          <div class="demo-visual-ring demo-visual-ring--outer"></div>
+          <div class="demo-visual-ring demo-visual-ring--inner"></div>
+          <div class="demo-visual-core"><div><strong>SHA-256</strong><span>COMPARAISON LOCALE</span></div></div>
+          <span class="demo-node demo-node--expected">COPIE A</span>
+          <span class="demo-node demo-node--declared">EMPREINTE A</span>
+          <span class="demo-node demo-node--evidence">COPIE B</span>
+          <span class="demo-node demo-node--unresolved">IDENTIQUES ?</span>
+        </div>
+      </div>
     </header>
 
-    <section class="verify-workspace">
-      <div class="wrap verify-grid">
-        <div class="verify-input">
-          <div class="workspace-head">
-<span>ENTRÉE RPO · JSON</span><button type="button" id="loadExample">CHARGER L’EXEMPLE</button>
-</div>
-          <textarea id="rpoInput" spellcheck="false" aria-label="Entrée JSON RPO" placeholder="Collez ici un objet RPO au format JSON…"></textarea>
-          <div class="verify-actions">
-<button class="btn primary" type="button" id="verifyObject">LANCER LA VÉRIFICATION</button><button class="btn" type="button" id="clearObject">EFFACER</button>
-</div>
-          <p class="local-note">TRAITEMENT LOCAL · AUCUN ENVOI · WEB CRYPTO SHA-256</p>
-        </div>
-        <div class="verify-output" aria-live="polite">
-          <p class="section-index">RAPPORT DE VÉRIFICATION</p>
-          <div class="verification-state" id="verificationState">
-<i></i><span>PRÊT</span>
-</div>
-          <dl>
-            <div>
-<dt>Syntaxe JSON</dt>
-<dd id="syntaxResult">—</dd>
-</div>
-            <div>
-<dt>Structure requise</dt>
-<dd id="structureResult">—</dd>
-</div>
-            <div>
-<dt>Octets canoniques</dt>
-<dd id="bytesResult">—</dd>
-</div>
-            <div class="hash-row">
-<dt>SHA-256</dt>
-<dd id="hashResult">—</dd>
-</div>
-          </dl>
-          <div class="report-boundary">
-            <p><strong>Ce rapport établit :</strong> la lisibilité du JSON, la présence des champs fondamentaux et l’empreinte reproductible de l’objet fourni.</p>
-            <p><strong>Il n’établit pas :</strong> la véracité des déclarations, l’authenticité externe des pièces ni une conclusion juridique.</p>
-            </div>
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">01 · TROIS ÉTAPES</p>
+        <h2>LA VÉRIFICATION DEVIENT CLAIRE LORSQU’ON VOIT CE QUI CHANGE.</h2>
+        <div class="verify-steps" style="margin-top:42px">
+          <article class="verify-step"><b>01</b><h3>Charger la copie de référence</h3><p>Le navigateur télécharge le RPO fictif présenté sur la page Exemple.</p></article>
+          <article class="verify-step"><b>02</b><h3>Calculer son empreinte</h3><p>Les clés sont ordonnées de façon stable, puis une empreinte SHA-256 est calculée localement.</p></article>
+          <article class="verify-step"><b>03</b><h3>Comparer après modification</h3><p>Un seul caractère différent produit une nouvelle empreinte et montre que les deux copies ne sont plus identiques.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="verify-method">
-      <div class="wrap">
-        <p class="section-index">MÉTHODE DÉTERMINISTE</p>
-        <div class="method-grid">
-          <article><b>01</b><h3>Lecture</h3>
-<p>Syntaxe JSON valide.</p></article>
-          <article><b>02</b><h3>Inspection</h3>
-<p>Champs RPO requis.</p></article>
-          <article><b>03</b><h3>Canonicalisation</h3>
-<p>Ordre récursif stable des clés.</p></article>
-          <article><b>04</b><h3>Empreinte</h3>
-<p>SHA-256 dans le navigateur.</p></article>
+    <section class="demo-section" id="laboratory">
+      <div class="demo-wrap">
+        <p class="demo-index">02 · ESSAYEZ VOUS-MÊME</p>
+        <h2>UN CLIC POUR VOIR L’INTÉGRITÉ. UN AUTRE POUR VOIR LA MODIFICATION.</h2>
+        <div class="verify-lab" style="margin-top:46px">
+          <aside class="verify-control">
+            <div class="verify-control-head"><p class="demo-index">DÉMONSTRATION GUIDÉE</p><h3>Que souhaitez-vous observer ?</h3></div>
+            <div class="verify-control-copy"><p>Commencez par la copie d’origine, puis simulez une modification. Le contenu reste lisible, mais son empreinte ne correspond plus à la référence.</p></div>
+            <div class="verify-buttons">
+              <button class="btn primary" type="button" data-action="check-original">VÉRIFIER LA COPIE D’ORIGINE</button>
+              <button class="btn" type="button" data-action="mutate">SIMULER UNE MODIFICATION</button>
+              <button class="btn" type="button" data-action="restore">RESTAURER L’ORIGINAL</button>
+            </div>
+          </aside>
+          <div>
+            <div class="verify-report">
+              <div class="verify-state" id="verificationState"><i></i><span>PRÊT</span></div>
+              <dl class="verify-result-grid">
+                <div class="verify-result"><dt>JSON lisible</dt><dd id="syntaxResult">—</dd></div>
+                <div class="verify-result"><dt>Structure RPO de base</dt><dd id="structureResult">—</dd></div>
+                <div class="verify-result"><dt>Comparaison à la référence</dt><dd id="matchResult">—</dd></div>
+                <div class="verify-result"><dt>Octets analysés</dt><dd id="bytesResult">—</dd></div>
+                <div class="verify-result verify-result--hash"><dt>Empreinte SHA-256 actuelle</dt><dd id="hashResult">—</dd></div>
+              </dl>
+            </div>
+            <div class="verify-reference"><strong>Empreinte de la copie de référence :</strong><br><span id="referenceHash">—</span><p style="margin:12px 0 0">La comparaison utilise la copie publique chargée au démarrage. Elle démontre la détection d’une modification ; elle ne remplace pas encore un ancrage dans un registre externe.</p><p id="simulationNote" style="margin:10px 0 0;color:var(--pale)"></p></div>
+            <details class="verify-advanced">
+              <summary>Voir ou modifier le JSON technique</summary>
+              <textarea class="verify-editor" id="rpoEditor" spellcheck="false" aria-label="Voir ou modifier le JSON technique"></textarea>
+              <div class="verify-editor-actions">
+                <button class="btn primary" type="button" id="runVerification">LANCER LA VÉRIFICATION</button>
+                <button class="btn" type="button" data-action="restore">RECHARGER L’ORIGINAL</button>
+              </div>
+            </details>
+          </div>
         </div>
+      </div>
+    </section>
+
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">03 · CE QUE LE CONTRÔLE ÉTABLIT</p>
+        <h2>L’INTÉGRITÉ EST UNE QUESTION DIFFÉRENTE DE LA VÉRITÉ.</h2>
+        <div class="verify-proof-grid" style="margin-top:42px">
+          <article class="verify-proof-card"><h3>Ce contrôle peut établir</h3><ul><li>que le texte est un JSON lisible ;</li><li>que les sections fondamentales du RPO sont présentes ;</li><li>l’empreinte exacte de la copie fournie ;</li><li>si cette copie est identique à la référence chargée.</li></ul></article>
+          <article class="verify-proof-card verify-proof-card--limit"><h3>Ce contrôle ne peut pas établir</h3><ul><li>que les déclarations contenues sont vraies ;</li><li>que les pièces sources sont authentiques hors du RPO ;</li><li>qui est juridiquement responsable ;</li><li>qu’une conclusion humaine ou juridique est correcte.</li></ul></article>
+        </div>
+        <p class="verify-note">Une vérification RPO complète pourra aussi inclure le schéma JSON, les signatures, les empreintes des pièces et la confirmation d’une entrée de registre. Cette page montre volontairement le mécanisme le plus simple : une copie identique produit la même empreinte ; une copie modifiée en produit une autre.</p>
       </div>
     </section>
   </main>
-
-  <footer class="footer rpo-footer"><div class="wrap">
-<div>
-<strong>RPO v0.1</strong><p>Spécification technique publique maintenue par OpenProof.</p>
-</div>
-<div class="footer-links">
-<a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a><a href="/fr/">Spécification</a><a href="https://openproof.net">OpenProof</a>
-</div>
-</div></footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script>
-    (() => {
-      const $ = selector => document.querySelector(selector);
-      const input = $('#rpoInput');
-      const required = ['rpo_version','type','bundle_id','created_at','issuer','subject','evidence','narrative','registry'];
-      const stable = value => {
-        if (Array.isArray(value)) return '[' + value.map(stable).join(',') + ']';
-        if (value && typeof value === 'object') return '{' + Object.keys(value).sort().map(key => JSON.stringify(key) + ':' + stable(value[key])).join(',') + '}';
-        return JSON.stringify(value);
-      };
-      const digest = async text => {
-        const bytes = new TextEncoder().encode(text);
-        const hash = await crypto.subtle.digest('SHA-256', bytes);
-        return { bytes: bytes.byteLength, hex: [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2,'0')).join('') };
-      };
-      const setState = (kind, label) => {
-        const state = $('#verificationState');
-        state.className = 'verification-state ' + kind;
-        state.querySelector('span').textContent = label;
-      };
-      const reset = () => {
-        ['#syntaxResult','#structureResult','#bytesResult','#hashResult'].forEach(id => $(id).textContent = '—');
-        setState('', 'PRÊT');
-      };
-      const load = () => fetch('https://raw.githubusercontent.com/openproof-net/rpo-spec-v0.1/main/examples/example-minimal/rpo.json')
-        .then(response => response.text()).then(text => { input.value = text; reset(); });
-      $('#loadExample').addEventListener('click', load);
-      $('#clearObject').addEventListener('click', () => { input.value = ''; reset(); });
-      $('#verifyObject').addEventListener('click', async () => {
-        reset();
-        try {
-          const object = JSON.parse(input.value);
-          $('#syntaxResult').textContent = 'CONFORME';
-          const missing = required.filter(field => !(field in object));
-          $('#structureResult').textContent = missing.length ? 'MANQUANT · ' + missing.join(', ') : 'CONFORME · RPO v' + object.rpo_version;
-          const result = await digest(stable(object));
-          $('#bytesResult').textContent = result.bytes.toLocaleString() + ' OCTETS';
-          $('#hashResult').textContent = result.hex;
-          setState(missing.length ? 'warning' : 'success', missing.length ? 'STRUCTURE INCOMPLÈTE' : 'VÉRIFICATION TERMINÉE');
-        } catch (error) {
-          $('#syntaxResult').textContent = 'ÉCHEC · JSON INVALIDE';
-          setState('failure', 'ÉCHEC DE LA VÉRIFICATION');
-        }
-      });
-      load();
-    })();
-  </script>
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>RPO v0.1</strong><p>Spécification publique maintenue par OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/fr/">Spécification</a>
+        <a href="/fr/truthx-engine/">TruthX Engine</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-5"></script>
+  <script src="/assets/rpo-demonstration.js?v=20260805-1"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,9 +9,9 @@
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
-<meta property="og:type" content="website">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
+  <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
   <meta property="og:title" content="Registered Probative Object (RPO) — Public Specification">
   <meta property="og:description" content="Public specification of the Registered Probative Object (RPO): sealed core, evidence provenance, explicit reservations and independently verifiable SHA-256 integrity.">
@@ -23,41 +23,39 @@
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": "WebSite",
-      "@id": "https://rpo.openproof.net/#website",
-      "url": "https://rpo.openproof.net/",
-      "name": "RPO Public Specification",
-      "publisher": {
-        "@id": "https://openproof.net/#organization"
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://rpo.openproof.net/#website",
+        "url": "https://rpo.openproof.net/",
+        "name": "RPO Public Specification",
+        "publisher": { "@id": "https://openproof.net/#organization" },
+        "inLanguage": "en"
       },
-      "inLanguage": "en"
-    },
-    {
-      "@type": "TechArticle",
-      "@id": "https://rpo.openproof.net/#specification",
-      "headline": "Registered Probative Object (RPO) Public Specification v0.1",
-      "description": "Public specification for a stable, traceable and independently verifiable probative object.",
-      "url": "https://rpo.openproof.net/",
-      "author": {
-        "@type": "Organization",
-        "name": "OpenProof",
-        "url": "https://openproof.net"
-      },
-      "about": [
-        "Registered Probative Object",
-        "evidence provenance",
-        "canonical JSON",
-        "SHA-256 integrity",
-        "probative infrastructure"
-      ],
-      "version": "0.1",
-      "inLanguage": "en"
-    }
-  ]
-}
+      {
+        "@type": "TechArticle",
+        "@id": "https://rpo.openproof.net/#specification",
+        "headline": "Registered Probative Object (RPO) Public Specification v0.1",
+        "description": "Public specification for a stable, traceable and independently verifiable probative object.",
+        "url": "https://rpo.openproof.net/",
+        "author": {
+          "@type": "Organization",
+          "name": "OpenProof",
+          "url": "https://openproof.net"
+        },
+        "about": [
+          "Registered Probative Object",
+          "evidence provenance",
+          "canonical JSON",
+          "SHA-256 integrity",
+          "probative infrastructure"
+        ],
+        "version": "0.1",
+        "inLanguage": "en"
+      }
+    ]
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="manifest" href="/site.webmanifest">
@@ -65,8 +63,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="en_US">
-<meta property="og:locale:alternate" content="fr_FR">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
 </head>
 <body class="rpo-home">
   <a class="skip" href="#main">Skip to content</a>
@@ -77,13 +75,19 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Open menu">Menu</button>
       <div class="links">
-        <a href="/" aria-current="page">Specification</a><a href="/examples.html">Example</a><a href="/tests.html">Verify</a><a href="/gersende-de-parcey.html">Founder</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/" aria-current="page">Specification</a>
+        <a href="/examples.html">See an RPO</a>
+        <a href="/tests.html">Verify an RPO</a>
+        <a href="/gersende-de-parcey.html">Founder</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Language">
-<a href="/fr/" lang="fr" hreflang="fr">FR</a><span aria-hidden="true">|</span><a href="/" lang="en" hreflang="en" aria-current="page">EN</a>
-</div>
+        <a href="/fr/" lang="fr" hreflang="fr">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/" lang="en" hreflang="en" aria-current="page">EN</a>
+      </div>
     </div>
   </nav>
 
@@ -93,19 +97,11 @@
       <div class="wrap rpo-hero-grid">
         <div class="rpo-copy">
           <p class="eyebrow">OPENPROOF · PUBLIC STANDARD · V0.1</p>
-          <h1>
-            <span>One probative object.<br>Stable. Verifiable. Defensible.</span>
-          </h1>
-          <p class="rpo-lead">
-            <span>The RPO is the public format produced by OpenProof to preserve a structured record, its sources, reservations and integrity — without confusing verification with truth.</span>
-          </p>
+          <h1><span>One probative object.<br>Stable. Verifiable. Defensible.</span></h1>
+          <p class="rpo-lead"><span>The RPO is the public format produced by OpenProof to preserve a structured record, its sources, reservations and integrity — without confusing verification with truth.</span></p>
           <div class="rpo-actions">
-            <a class="btn primary" href="/">
-              <span>Read the specification</span>
-            </a>
-            <a class="btn" href="/examples.html">
-              <span>View an RPO</span>
-            </a>
+            <a class="btn primary" href="#definition-title"><span>Understand the RPO</span></a>
+            <a class="btn" href="/examples.html"><span>See an RPO</span></a>
           </div>
           <p class="version-line">RPO v0.1 · JSON · SHA-256 · deterministic verification</p>
         </div>
@@ -119,18 +115,10 @@
             <strong>RPO</strong>
             <span>REGISTERED<br>PROBATIVE OBJECT</span>
           </div>
-          <div class="rpo-signal signal-source">
-<i></i><span>SOURCES</span>
-</div>
-          <div class="rpo-signal signal-structure">
-<i></i><span>STRUCTURE</span>
-</div>
-          <div class="rpo-signal signal-reserve">
-<i></i><span>RESERVATIONS</span>
-</div>
-          <div class="rpo-signal signal-hash">
-<i></i><span>INTEGRITY HASH</span>
-</div>
+          <div class="rpo-signal signal-source"><i></i><span>SOURCES</span></div>
+          <div class="rpo-signal signal-structure"><i></i><span>STRUCTURE</span></div>
+          <div class="rpo-signal signal-reserve"><i></i><span>RESERVATIONS</span></div>
+          <div class="rpo-signal signal-hash"><i></i><span>INTEGRITY HASH</span></div>
         </div>
       </div>
     </header>
@@ -139,14 +127,10 @@
       <div class="wrap">
         <p class="section-index">01 · DEFINITION</p>
         <div class="definition-grid">
-          <h2 id="definition-title">
-            <span>What the RPO guarantees.<br>And what it does not claim to guarantee.</span>
-          </h2>
+          <h2 id="definition-title"><span>What the RPO guarantees.<br>And what it does not claim to guarantee.</span></h2>
           <div class="definition-copy">
             <p>An RPO makes any change to the sealed core detectable. It preserves the provenance, transformations and reservations required for independent review.</p>
-            <p class="boundary">
-              <span><strong>Essential boundary:</strong> object integrity does not prove content truth. OpenProof structures and makes records verifiable; it does not adjudicate.</span>
-            </p>
+            <p class="boundary"><span><strong>Essential boundary:</strong> object integrity does not prove content truth. OpenProof structures and makes records verifiable; it does not adjudicate.</span></p>
           </div>
         </div>
       </div>
@@ -155,26 +139,12 @@
     <section class="rpo-anatomy" aria-labelledby="anatomy-title">
       <div class="wrap">
         <p class="section-index">02 · ANATOMY</p>
-        <h2 id="anatomy-title">
-          <span>Four elements. One reproducible trace.</span>
-        </h2>
+        <h2 id="anatomy-title"><span>Four elements. One reproducible trace.</span></h2>
         <div class="anatomy-grid">
-          <article>
-            <span>01</span><h3>Sealed core</h3>
-            <p>The record’s canonical JSON core.</p>
-          </article>
-          <article>
-            <span>02</span><h3>Evidence manifest</h3>
-            <p>Sources, identifiers and provenance.</p>
-          </article>
-          <article>
-            <span>03</span><h3>Reservations</h3>
-            <p>Explicit gaps, contradictions and limits.</p>
-          </article>
-          <article>
-            <span>04</span><h3>Public hash</h3>
-            <p>The SHA-256 fingerprint used to detect alteration.</p>
-          </article>
+          <article><span>01</span><h3>Sealed core</h3><p>The record’s canonical JSON core.</p></article>
+          <article><span>02</span><h3>Evidence manifest</h3><p>Sources, identifiers and provenance.</p></article>
+          <article><span>03</span><h3>Reservations</h3><p>Explicit gaps, contradictions and limits.</p></article>
+          <article><span>04</span><h3>Public fingerprint</h3><p>The SHA-256 fingerprint used to detect alteration.</p></article>
         </div>
       </div>
     </section>
@@ -182,55 +152,44 @@
     <section class="rpo-paths" aria-labelledby="paths-title">
       <div class="wrap">
         <p class="section-index">03 · PUBLIC ACCESS</p>
-        <h2 id="paths-title">
-          <span>Three entry points. Nothing more.</span>
-        </h2>
+        <h2 id="paths-title"><span>Understand. See. Verify.</span></h2>
         <div class="path-grid">
-          <a href="/">
-            <span>SPECIFICATION</span><strong>01</strong>
-            <h3>Understand the format</h3>
-            <p>Schema, canonical serialization, hashing and conformance.</p>
-            <i>Open specification →</i>
+          <a href="#definition-title">
+            <span>UNDERSTAND</span><strong>01</strong>
+            <h3>Understand the RPO</h3>
+            <p>What the format preserves, guarantees and deliberately does not decide.</p>
+            <i>Read the public specification →</i>
           </a>
           <a href="/examples.html">
-            <span>EXAMPLE</span><strong>02</strong>
-            <h3>Inspect an object</h3>
-            <p>A sample bundle readable by humans and machines.</p>
-            <i>Open example →</i>
+            <span>SEE</span><strong>02</strong>
+            <h3>Follow a fictional situation</h3>
+            <p>Read the project gap in plain language before opening the technical JSON.</p>
+            <i>See an RPO →</i>
           </a>
           <a href="/tests.html">
             <span>VERIFY</span><strong>03</strong>
-            <h3>Reproduce verification</h3>
-            <p>Test vectors and expected results, independently of OpenProof.</p>
-            <i>Open verification →</i>
+            <h3>Detect a modification</h3>
+            <p>Change one detail and watch the local SHA-256 fingerprint change immediately.</p>
+            <i>Verify an RPO →</i>
           </a>
         </div>
       </div>
     </section>
 
-    <section class="architecture-line" aria-label="Architecture de marque">
+    <section class="architecture-line" aria-label="Brand architecture">
       <div class="wrap">
-        <div>
-<span>OPENPROOF</span><strong>Probative infrastructure</strong>
-</div>
+        <div><span>OPENPROOF</span><strong>Probative infrastructure</strong></div>
         <b aria-hidden="true">→</b>
-        <div>
-<span>TRUTHX ENGINE</span><strong>Deterministic structuring engine</strong>
-</div>
+        <div><span>TRUTHX ENGINE</span><strong>Deterministic structuring engine</strong></div>
         <b aria-hidden="true">→</b>
-        <div>
-<span>RPO</span><strong>Registered probative object</strong>
-</div>
+        <div><span>RPO</span><strong>Registered probative object</strong></div>
       </div>
     </section>
   </main>
 
   <footer class="footer rpo-footer">
     <div class="wrap">
-      <div>
-        <strong>RPO v0.1</strong>
-        <p>Public technical specification maintained by OpenProof.</p>
-      </div>
+      <div><strong>RPO v0.1</strong><p>Public technical specification maintained by OpenProof.</p></div>
       <div class="footer-links">
         <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
         <a href="/">Specification</a>
@@ -239,6 +198,6 @@
       </div>
     </div>
   </footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
+  <script src="/assets/openproof-v2.js?v=20260805-6"></script>
 </body>
 </html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,7 +3,7 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://rpo.openproof.net/</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/"/>
@@ -12,7 +12,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/fr/</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/"/>
@@ -39,7 +39,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/examples.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/examples.html"/>
@@ -48,7 +48,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/fr/examples.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/examples.html"/>
@@ -57,7 +57,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/tests.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/tests.html"/>
@@ -66,7 +66,7 @@
   </url>
   <url>
     <loc>https://rpo.openproof.net/fr/tests.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://rpo.openproof.net/tests.html"/>

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -4,50 +4,51 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>Verify an RPO: Canonical JSON &amp; SHA-256 | OpenProof</title>
-  <meta name="description" content="Verify a Registered Probative Object locally: required structure, deterministic canonical JSON serialization and reproducible SHA-256 integrity fingerprint.">
+  <title>Verify an RPO Without Trusting OpenProof | OpenProof</title>
+  <meta name="description" content="Load a public copy, compute its fingerprint in your browser, change one detail and see the difference immediately.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/tests.html">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/tests.html">
-<link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/tests.html">
-<link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/tests.html">
-<meta property="og:type" content="website">
+  <link rel="alternate" hreflang="fr" href="https://rpo.openproof.net/fr/tests.html">
+  <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/tests.html">
+  <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="Verify an RPO: Canonical JSON &amp; SHA-256">
-  <meta property="og:description" content="Verify a Registered Probative Object locally: required structure, deterministic canonical JSON serialization and reproducible SHA-256 integrity fingerprint.">
+  <meta property="og:title" content="Detect whether an RPO has changed">
+  <meta property="og:description" content="Load a public copy, compute its fingerprint in your browser, change one detail and see the difference immediately.">
   <meta property="og:url" content="https://rpo.openproof.net/tests.html">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Verify an RPO: Canonical JSON &amp; SHA-256">
-  <meta name="twitter:description" content="Verify a Registered Probative Object locally: required structure, deterministic canonical JSON serialization and reproducible SHA-256 integrity fingerprint.">
+  <meta name="twitter:title" content="Detect whether an RPO has changed">
+  <meta name="twitter:description" content="Load a public copy, compute its fingerprint in your browser, change one detail and see the difference immediately.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "RPO Verification Tool",
-  "applicationCategory": "DeveloperApplication",
-  "operatingSystem": "Any modern web browser",
-  "url": "https://rpo.openproof.net/tests.html",
-  "description": "Local verification of Registered Probative Object structure, canonical JSON serialization and SHA-256 integrity.",
-  "isAccessibleForFree": true,
-  "publisher": {
-    "@type": "Organization",
-    "name": "OpenProof",
-    "url": "https://openproof.net"
-  },
-  "inLanguage": "en"
-}
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Educational RPO verification tool",
+    "headline": "Educational RPO verification tool",
+    "url": "https://rpo.openproof.net/tests.html",
+    "description": "Load a public copy, compute its fingerprint in your browser, change one detail and see the difference immediately.",
+    "applicationCategory": "EducationalApplication",
+    "isAccessibleForFree": true,
+    "publisher": {
+      "@type": "Organization",
+      "name": "OpenProof",
+      "url": "https://openproof.net"
+    },
+    "inLanguage": "en"
+  }
   </script>
   <link rel="icon" href="/assets/openproof-icon.svg?v=20260731-2" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-<meta property="og:locale" content="en_US">
-<meta property="og:locale:alternate" content="fr_FR">
+  <link rel="stylesheet" href="/assets/rpo-demonstration.css?v=20260805-1">
 </head>
-<body class="rpo-home rpo-subpage">
+<body class="rpo-home rpo-subpage rpo-verify-page" data-rpo-demo-page data-demo-src="/examples/public-demo/rpo-en.json">
   <a class="skip" href="#main">Skip to content</a>
   <nav class="nav" aria-label="Primary navigation">
     <div class="wrap navin">
@@ -55,143 +56,123 @@
         <img src="/assets/openproof-icon.svg?v=20260731-2" alt="" width="38" height="38">
         <span><strong>OPENPROOF</strong><small>RPO PUBLIC SPECIFICATION</small></span>
       </a>
-      <button class="menu" aria-expanded="false" aria-label="Open menu">Menu</button>
+      <button class="menu" type="button" aria-expanded="false" aria-label="Open menu">Menu</button>
       <div class="links">
-        <a href="/">Specification</a><a href="/examples.html">Example</a><a href="/tests.html" aria-current="page">Verify</a><a href="/gersende-de-parcey.html">Founder</a><a href="https://openproof.net" class="external-link">OpenProof ↗</a>
-</div>
+        <a href="/">Specification</a>
+        <a href="/examples.html">See an RPO</a>
+        <a href="/tests.html" aria-current="page">Verify an RPO</a>
+        <a href="/gersende-de-parcey.html">Founder</a>
+        <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
+      </div>
       <div class="language" aria-label="Language">
-<a href="/fr/tests.html" lang="fr" hreflang="fr">FR</a><span aria-hidden="true">|</span><a href="/tests.html" lang="en" hreflang="en" aria-current="page">EN</a>
-</div>
+        <a href="/fr/tests.html" lang="fr" hreflang="fr">FR</a>
+        <span aria-hidden="true">|</span>
+        <a href="/tests.html" lang="en" hreflang="en" aria-current="page">EN</a>
+      </div>
     </div>
   </nav>
 
   <main id="main">
-    <header class="sub-hero cosmos">
+    <header class="demo-hero cosmos">
       <canvas class="stars" aria-hidden="true"></canvas>
-      <div class="wrap">
-        <p class="eyebrow">03 · VERIFY · LOCAL EXECUTION</p>
-        <h1>
-          <span>Verify, without trusting us.</span>
-        </h1>
-        <p class="sub-lead">The check runs in your browser. No object is sent to OpenProof: structure is inspected, JSON is serialized deterministically, then its SHA-256 fingerprint is computed locally.</p>
+      <div class="demo-wrap">
+        <div class="demo-hero-copy">
+          <p class="demo-kicker">03 · VERIFY AN RPO · LOCAL EXECUTION</p>
+          <h1>CAN WE DETECT WHETHER THIS RPO CHANGED?<span>YES. CHANGE ONE WORD AND THE FINGERPRINT CHANGES.</span></h1>
+          <p class="demo-hero-lead">This page loads the public demonstration copy, computes its fingerprint in your browser and compares it with the reference copy. No file is sent to OpenProof.</p>
+          <div class="demo-actions">
+            <a class="btn primary" href="#laboratory">Run the demonstration</a>
+            <a class="btn" href="/examples.html">Review the example</a>
+          </div>
+          <p class="demo-one-line">You do not need to understand JSON: click “Simulate a change”, then watch the verification state change.</p>
+        </div>
+        <div class="demo-visual" aria-label="RPO fingerprint comparison">
+          <div class="demo-visual-ring demo-visual-ring--outer"></div>
+          <div class="demo-visual-ring demo-visual-ring--inner"></div>
+          <div class="demo-visual-core"><div><strong>SHA-256</strong><span>LOCAL COMPARISON</span></div></div>
+          <span class="demo-node demo-node--expected">COPY A</span>
+          <span class="demo-node demo-node--declared">HASH A</span>
+          <span class="demo-node demo-node--evidence">COPY B</span>
+          <span class="demo-node demo-node--unresolved">IDENTICAL?</span>
+        </div>
       </div>
     </header>
 
-    <section class="verify-workspace">
-      <div class="wrap verify-grid">
-        <div class="verify-input">
-          <div class="workspace-head">
-<span>RPO INPUT · JSON</span><button type="button" id="loadExample">LOAD EXAMPLE</button>
-</div>
-          <textarea id="rpoInput" spellcheck="false" aria-label="RPO JSON input" placeholder="Paste an RPO JSON object here…"></textarea>
-          <div class="verify-actions">
-<button class="btn primary" type="button" id="verifyObject">RUN VERIFICATION</button><button class="btn" type="button" id="clearObject">CLEAR</button>
-</div>
-          <p class="local-note">LOCAL ONLY · NO UPLOAD · WEB CRYPTO SHA-256</p>
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">01 · THREE STEPS</p>
+        <h2>VERIFICATION BECOMES CLEAR WHEN YOU CAN SEE WHAT CHANGES.</h2>
+        <div class="verify-steps" style="margin-top:42px">
+          <article class="verify-step"><b>01</b><h3>Load the reference copy</h3><p>The browser downloads the fictional RPO shown on the Example page.</p></article>
+          <article class="verify-step"><b>02</b><h3>Compute its fingerprint</h3><p>Keys are ordered consistently, then a SHA-256 fingerprint is calculated locally.</p></article>
+          <article class="verify-step"><b>03</b><h3>Compare after a change</h3><p>A single different character produces another fingerprint and shows that the two copies are no longer identical.</p></article>
         </div>
-        <div class="verify-output" aria-live="polite">
-          <p class="section-index">VERIFICATION REPORT</p>
-          <div class="verification-state" id="verificationState">
-<i></i><span>READY</span>
-</div>
-          <dl>
-            <div>
-<dt>JSON syntax</dt>
-<dd id="syntaxResult">—</dd>
-</div>
-            <div>
-<dt>Required structure</dt>
-<dd id="structureResult">—</dd>
-</div>
-            <div>
-<dt>Canonical bytes</dt>
-<dd id="bytesResult">—</dd>
-</div>
-            <div class="hash-row">
-<dt>SHA-256</dt>
-<dd id="hashResult">—</dd>
-</div>
-          </dl>
-          <div class="report-boundary">
-            <p><strong>This report establishes:</strong> JSON readability, presence of fundamental fields and the reproducible fingerprint of the supplied object.</p>
-            <p><strong>It does not establish:</strong> truth of statements, external authenticity of evidence or a legal conclusion.</p>
+      </div>
+    </section>
+
+    <section class="demo-section" id="laboratory">
+      <div class="demo-wrap">
+        <p class="demo-index">02 · TRY IT YOURSELF</p>
+        <h2>ONE CLICK TO SEE INTEGRITY. ANOTHER TO SEE A CHANGE.</h2>
+        <div class="verify-lab" style="margin-top:46px">
+          <aside class="verify-control">
+            <div class="verify-control-head"><p class="demo-index">GUIDED DEMONSTRATION</p><h3>What do you want to observe?</h3></div>
+            <div class="verify-control-copy"><p>Start with the original copy, then simulate a change. The content remains readable, but its fingerprint no longer matches the reference.</p></div>
+            <div class="verify-buttons">
+              <button class="btn primary" type="button" data-action="check-original">CHECK THE ORIGINAL COPY</button>
+              <button class="btn" type="button" data-action="mutate">SIMULATE A CHANGE</button>
+              <button class="btn" type="button" data-action="restore">RESTORE THE ORIGINAL</button>
+            </div>
+          </aside>
+          <div>
+            <div class="verify-report">
+              <div class="verify-state" id="verificationState"><i></i><span>READY</span></div>
+              <dl class="verify-result-grid">
+                <div class="verify-result"><dt>Readable JSON</dt><dd id="syntaxResult">—</dd></div>
+                <div class="verify-result"><dt>Basic RPO structure</dt><dd id="structureResult">—</dd></div>
+                <div class="verify-result"><dt>Reference comparison</dt><dd id="matchResult">—</dd></div>
+                <div class="verify-result"><dt>Bytes analysed</dt><dd id="bytesResult">—</dd></div>
+                <div class="verify-result verify-result--hash"><dt>Current SHA-256 fingerprint</dt><dd id="hashResult">—</dd></div>
+              </dl>
+            </div>
+            <div class="verify-reference"><strong>Reference-copy fingerprint:</strong><br><span id="referenceHash">—</span><p style="margin:12px 0 0">The comparison uses the public copy loaded when the page starts. It demonstrates change detection; it is not yet a substitute for anchoring in an external registry.</p><p id="simulationNote" style="margin:10px 0 0;color:var(--pale)"></p></div>
+            <details class="verify-advanced">
+              <summary>View or edit the technical JSON</summary>
+              <textarea class="verify-editor" id="rpoEditor" spellcheck="false" aria-label="View or edit the technical JSON"></textarea>
+              <div class="verify-editor-actions">
+                <button class="btn primary" type="button" id="runVerification">RUN VERIFICATION</button>
+                <button class="btn" type="button" data-action="restore">RELOAD ORIGINAL</button>
+              </div>
+            </details>
           </div>
         </div>
       </div>
     </section>
 
-    <section class="verify-method">
-      <div class="wrap">
-        <p class="section-index">DETERMINISTIC METHOD</p>
-        <div class="method-grid">
-          <article><b>01</b><h3>Parse</h3>
-<p>Valid JSON syntax.</p></article>
-          <article><b>02</b><h3>Inspect</h3>
-<p>Required RPO fields.</p></article>
-          <article><b>03</b><h3>Canonicalize</h3>
-<p>Stable recursive key order.</p></article>
-          <article><b>04</b><h3>Hash</h3>
-<p>SHA-256 in the browser.</p></article>
+    <section class="demo-section">
+      <div class="demo-wrap">
+        <p class="demo-index">03 · WHAT THE CHECK ESTABLISHES</p>
+        <h2>INTEGRITY IS A DIFFERENT QUESTION FROM TRUTH.</h2>
+        <div class="verify-proof-grid" style="margin-top:42px">
+          <article class="verify-proof-card"><h3>This check can establish</h3><ul><li>that the text is readable JSON;</li><li>that the fundamental RPO sections are present;</li><li>the exact fingerprint of the supplied copy;</li><li>whether this copy is identical to the loaded reference.</li></ul></article>
+          <article class="verify-proof-card verify-proof-card--limit"><h3>This check cannot establish</h3><ul><li>that the statements inside are true;</li><li>that source evidence is authentic outside the RPO;</li><li>who is legally responsible;</li><li>that a human or legal conclusion is correct.</li></ul></article>
         </div>
+        <p class="verify-note">Full RPO verification may also include JSON Schema validation, signatures, evidence-file fingerprints and confirmation of a registry entry. This page deliberately shows the simplest mechanism: an identical copy produces the same fingerprint; a changed copy produces another.</p>
       </div>
     </section>
   </main>
-
-  <footer class="footer rpo-footer"><div class="wrap">
-<div>
-<strong>RPO v0.1</strong><p>Public technical specification maintained by OpenProof.</p>
-</div>
-<div class="footer-links">
-<a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a><a href="/">Specification</a><a href="https://openproof.net">OpenProof</a>
-</div>
-</div></footer>
-  <script src="/assets/openproof-v2.js?v=20260731-1"></script>
-  <script>
-    (() => {
-      const $ = selector => document.querySelector(selector);
-      const input = $('#rpoInput');
-      const required = ['rpo_version','type','bundle_id','created_at','issuer','subject','evidence','narrative','registry'];
-      const stable = value => {
-        if (Array.isArray(value)) return '[' + value.map(stable).join(',') + ']';
-        if (value && typeof value === 'object') return '{' + Object.keys(value).sort().map(key => JSON.stringify(key) + ':' + stable(value[key])).join(',') + '}';
-        return JSON.stringify(value);
-      };
-      const digest = async text => {
-        const bytes = new TextEncoder().encode(text);
-        const hash = await crypto.subtle.digest('SHA-256', bytes);
-        return { bytes: bytes.byteLength, hex: [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2,'0')).join('') };
-      };
-      const setState = (kind, label) => {
-        const state = $('#verificationState');
-        state.className = 'verification-state ' + kind;
-        state.querySelector('span').textContent = label;
-      };
-      const reset = () => {
-        ['#syntaxResult','#structureResult','#bytesResult','#hashResult'].forEach(id => $(id).textContent = '—');
-        setState('', 'READY');
-      };
-      const load = () => fetch('https://raw.githubusercontent.com/openproof-net/rpo-spec-v0.1/main/examples/example-minimal/rpo.json')
-        .then(response => response.text()).then(text => { input.value = text; reset(); });
-      $('#loadExample').addEventListener('click', load);
-      $('#clearObject').addEventListener('click', () => { input.value = ''; reset(); });
-      $('#verifyObject').addEventListener('click', async () => {
-        reset();
-        try {
-          const object = JSON.parse(input.value);
-          $('#syntaxResult').textContent = 'PASS';
-          const missing = required.filter(field => !(field in object));
-          $('#structureResult').textContent = missing.length ? 'MISSING · ' + missing.join(', ') : 'PASS · RPO v' + object.rpo_version;
-          const result = await digest(stable(object));
-          $('#bytesResult').textContent = result.bytes.toLocaleString() + ' BYTES';
-          $('#hashResult').textContent = result.hex;
-          setState(missing.length ? 'warning' : 'success', missing.length ? 'STRUCTURE INCOMPLETE' : 'VERIFICATION COMPLETE');
-        } catch (error) {
-          $('#syntaxResult').textContent = 'FAIL · INVALID JSON';
-          setState('failure', 'VERIFICATION FAILED');
-        }
-      });
-      load();
-    })();
-  </script>
+  <footer class="footer rpo-footer">
+    <div class="wrap">
+      <div><strong>RPO v0.1</strong><p>Public specification maintained by OpenProof.</p></div>
+      <div class="footer-links">
+        <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
+        <a href="/">Specification</a>
+        <a href="/truthx-engine/">TruthX Engine</a>
+        <a href="https://openproof.net">OpenProof</a>
+      </div>
+    </div>
+  </footer>
+  <script src="/assets/openproof-v2.js?v=20260805-5"></script>
+  <script src="/assets/rpo-demonstration.js?v=20260805-1"></script>
 </body>
 </html>

--- a/examples/public-demo/rpo-en.json
+++ b/examples/public-demo/rpo-en.json
@@ -1,0 +1,52 @@
+{
+  "rpo_version": "0.1",
+  "type": "evidence_bundle",
+  "bundle_id": "9f9af5c8-d359-4da4-8a95-ef909b33747f",
+  "created_at": "2026-08-05T12:00:00Z",
+  "jurisdiction": "Fictional demonstration — no applicable jurisdiction",
+  "language": "en-GB",
+  "issuer": {
+    "name": "OpenProof — public demonstration",
+    "id": "urn:openproof:demo:issuer",
+    "role": "demonstration_issuer"
+  },
+  "subject": {
+    "name": "Project Atlas — ventilation system handover",
+    "id": "urn:openproof:demo:project-atlas",
+    "role": "project"
+  },
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "contract_requirement",
+      "description": "The contract requires a final ventilation test before handover.",
+      "hash": "sha256:a16b27f6220a5d98a38dbf80027949509f7148507da8b77a62b36424d3324b02",
+      "uri": "urn:openproof:demo:atlas:requirement"
+    },
+    {
+      "id": "ev-002",
+      "type": "progress_declaration",
+      "description": "The 15 July meeting minutes declare the building ready for handover.",
+      "hash": "sha256:e4c971510492d2ded5ac50257db393880eb1f5f638cb2cad0a55a970566a0b5f",
+      "uri": "urn:openproof:demo:atlas:minutes"
+    },
+    {
+      "id": "ev-003",
+      "type": "inspection_report",
+      "description": "The 16 July inspection report states that the final airflow test is still outstanding.",
+      "hash": "sha256:4b0fa8b5488385adba81fcc9538d90e3af9e316b37dfe831d791f6a0b1cc56fe",
+      "uri": "urn:openproof:demo:atlas:inspection"
+    }
+  ],
+  "narrative": {
+    "summary": "The building was declared ready for handover while the final ventilation test was still outstanding. The RPO preserves the requirement, the declaration, the inspection finding and the unresolved point without automatically deciding liability.",
+    "pdf_hash": "sha256:demo-public-no-pdf",
+    "timeline_ref": "ev-003"
+  },
+  "registry": {
+    "registry_id": "openproof-public-demo",
+    "entry_id": "demo-atlas-en-0001",
+    "public_hash": "sha256:reference-computed-locally-by-the-demo"
+  },
+  "signatures": []
+}

--- a/examples/public-demo/rpo-fr.json
+++ b/examples/public-demo/rpo-fr.json
@@ -1,0 +1,52 @@
+{
+  "rpo_version": "0.1",
+  "type": "evidence_bundle",
+  "bundle_id": "2d17e9b1-b615-4a47-a452-b2ec8ea11c63",
+  "created_at": "2026-08-05T12:00:00Z",
+  "jurisdiction": "Démonstration fictive — aucune juridiction applicable",
+  "language": "fr-FR",
+  "issuer": {
+    "name": "OpenProof — démonstration publique",
+    "id": "urn:openproof:demo:issuer",
+    "role": "demonstration_issuer"
+  },
+  "subject": {
+    "name": "Projet Atlas — réception d’un système de ventilation",
+    "id": "urn:openproof:demo:project-atlas",
+    "role": "project"
+  },
+  "evidence": [
+    {
+      "id": "ev-001",
+      "type": "contract_requirement",
+      "description": "Le contrat impose un test final de ventilation avant la réception.",
+      "hash": "sha256:5ed14741ae1fc28e3e297d57b2d037ed1da1d338c55061f6baa09fadbfd5730d",
+      "uri": "urn:openproof:demo:atlas:requirement"
+    },
+    {
+      "id": "ev-002",
+      "type": "progress_declaration",
+      "description": "Le compte rendu du 15 juillet déclare le bâtiment prêt à être réceptionné.",
+      "hash": "sha256:5983f3859b0234723a4661dfb350801ed52eacdbf116c2ad5235b79a9a3f48ea",
+      "uri": "urn:openproof:demo:atlas:minutes"
+    },
+    {
+      "id": "ev-003",
+      "type": "inspection_report",
+      "description": "Le rapport d’inspection du 16 juillet indique que le test final de débit d’air reste à réaliser.",
+      "hash": "sha256:66e7d65d48891a1ee5866c44d73d4bd3009bf5804d8efd0f25f4971803664d6c",
+      "uri": "urn:openproof:demo:atlas:inspection"
+    }
+  ],
+  "narrative": {
+    "summary": "Le bâtiment a été déclaré prêt à être réceptionné alors que le test final de ventilation restait à réaliser. Le RPO conserve l’exigence, la déclaration, le constat d’inspection et le point non résolu, sans décider automatiquement d’une responsabilité.",
+    "pdf_hash": "sha256:demo-public-no-pdf",
+    "timeline_ref": "ev-003"
+  },
+  "registry": {
+    "registry_id": "openproof-public-demo",
+    "entry_id": "demo-atlas-fr-0001",
+    "public_hash": "sha256:reference-computed-locally-by-the-demo"
+  },
+  "signatures": []
+}


### PR DESCRIPTION
## Purpose

The public RPO journey was technically correct but too abstract for non-engineers. This PR rebuilds the homepage entry points, `/examples.html` and `/tests.html` in French and English so that a lawyer, executive, researcher, investor or project owner can understand the value before seeing JSON or SHA-256.

## Homepage

- renames the public paths to `See an RPO` / `Verify an RPO` and `Voir un RPO` / `Vérifier un RPO`;
- replaces the abstract three-card wording with a clear sequence: understand, see, verify;
- explains what each action gives the visitor;
- corrects mixed English/French labels on the French homepage.

## Public example

- replaces the former sensitive and placeholder-led presentation with a neutral fictional case: Project Atlas / Projet Atlas;
- starts with four human-readable elements: expected, declared, source, unresolved;
- explains why the RPO matters before exposing its technical format;
- separates the human view from the machine-readable JSON;
- retains the essential boundary: integrity does not establish material truth or legal liability;
- provides dedicated public FR and EN demo fixtures without claiming CNRS issuance.

## Verification page

- turns the developer-oriented textarea into a guided demonstration;
- automatically loads the public reference copy;
- lets the visitor verify the original, simulate a one-sentence change and restore the original;
- computes SHA-256 locally and compares the current copy with the loaded reference;
- clearly separates what the check establishes from what it cannot establish;
- keeps an advanced editable JSON view for technical users;
- explicitly states that this educational comparison is not yet an external registry anchor.

## Visual and editorial system

- preserves the canonical OpenProof / RPO charter;
- uses the same black, ivory, warm-metal and steel palette;
- keeps square panels, restrained separators and the institutional typography;
- justifies substantive editorial copy on desktop in both languages;
- preserves natural alignment for titles, labels, buttons and technical values;
- includes responsive and mobile layouts.

## Technical boundaries

- no change to TruthX Engine or private deterministic rules;
- no claim that content truth, evidence authenticity or legal responsibility is verified;
- no file upload: all demonstration hashing remains local in the browser;
- the reference comparison is explicitly described as an educational mechanism, not a substitute for registry anchoring.

## Files

- rebuilt EN/FR homepage, example and verification pages;
- new shared demonstration CSS and JavaScript;
- new fictional EN/FR demo fixtures under the public site and repository examples;
- refreshed sitemap dates.
