### PR TITLE
Upgrade the RPO homepage for semantic authority and SEO

### DIFF
--- a/docs/assets/openproof-v2.js
+++ b/docs/assets/openproof-v2.js
@@ -72,6 +72,14 @@
   const links = document.querySelector('.links');
   if (!links) return;
 
+  const staticTruthX = links.querySelector('[data-truthx-static]');
+  if (staticTruthX) {
+    if (location.pathname.includes('/truthx-engine/')) {
+      staticTruthX.setAttribute('aria-current', 'page');
+    }
+    return;
+  }
+
   const isFrench = document.documentElement.lang === 'fr';
   const base = isFrench ? '/fr/truthx-engine/' : '/truthx-engine/';
   const items = isFrench

--- a/docs/assets/rpo-home-authority.css
+++ b/docs/assets/rpo-home-authority.css
@@ -1,0 +1,279 @@
+/*
+ * RPO homepage authority layer
+ * Adds semantic depth and two pedagogical sections while preserving the canonical OpenProof charter.
+ */
+
+.rpo-authority-home .rpo-text-link{
+  display:inline-flex;
+  align-items:center;
+  min-height:42px;
+  padding:9px 0 7px;
+  border-bottom:1px solid rgba(225,195,138,.48);
+  color:#d0d3d1;
+  font:700 8px/1.2 Montserrat,sans-serif;
+  letter-spacing:1.2px;
+  text-decoration:none;
+  text-transform:uppercase;
+}
+
+.rpo-authority-home .rpo-text-link:hover,
+.rpo-authority-home .rpo-text-link:focus-visible{
+  border-color:var(--pale);
+  color:var(--pale);
+}
+
+.rpo-flow,
+.rpo-outcomes{
+  position:relative;
+  overflow:hidden;
+  padding:105px 0;
+  border-top:1px solid var(--line);
+}
+
+.rpo-flow{background:#080b0f}
+.rpo-outcomes{background:#0d1217}
+
+.rpo-authority-home .authority-heading{
+  display:grid;
+  grid-template-columns:minmax(0,1fr) minmax(320px,.42fr);
+  gap:72px;
+  align-items:end;
+  margin-bottom:44px;
+}
+
+.rpo-authority-home .authority-heading h2{
+  max-width:930px;
+  margin:16px 0 0;
+  color:#ece8df;
+  font:500 clamp(2.15rem,3.45vw,3.75rem)/1.08 Orbitron,Montserrat,sans-serif;
+  letter-spacing:-.03em;
+  text-transform:uppercase;
+  text-wrap:balance;
+}
+
+.rpo-authority-home .authority-heading>p{
+  margin:0 0 8px;
+  color:#9da6aa;
+  font-size:.94rem;
+  line-height:1.9;
+}
+
+.rpo-flow-grid{
+  display:grid;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  border-block:1px solid var(--line);
+}
+
+.rpo-flow-card{
+  position:relative;
+  min-height:292px;
+  padding:31px 28px 29px;
+  overflow:hidden;
+  border-right:1px solid var(--line);
+  background:linear-gradient(180deg,rgba(13,19,25,.96),rgba(5,8,11,.96));
+}
+
+.rpo-flow-card:last-child{border-right:0}
+
+.rpo-flow-card:not(:last-child)::after{
+  position:absolute;
+  top:50%;
+  right:-13px;
+  z-index:3;
+  display:grid;
+  width:26px;
+  height:26px;
+  place-items:center;
+  border:1px solid rgba(196,154,88,.42);
+  background:#080b0f;
+  color:var(--gold);
+  font:500 .75rem Orbitron,Montserrat,sans-serif;
+  transform:translateY(-50%);
+  content:"→";
+}
+
+.rpo-flow-card span,
+.rpo-outcome-card span{
+  color:var(--gold);
+  font:600 .61rem/1.4 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.13em;
+  text-transform:uppercase;
+}
+
+.rpo-flow-card h3,
+.rpo-outcome-card h3{
+  margin:31px 0 17px;
+  color:var(--pale);
+  font:600 .98rem/1.45 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.02em;
+}
+
+.rpo-flow-card p,
+.rpo-outcome-card p{
+  margin:0;
+  color:var(--soft);
+  font-size:.89rem;
+  line-height:1.82;
+}
+
+.rpo-flow-card strong{
+  display:block;
+  margin-top:24px;
+  padding-top:19px;
+  border-top:1px solid rgba(255,255,255,.07);
+  color:#c8ccc8;
+  font-size:.73rem;
+  font-weight:500;
+  line-height:1.65;
+}
+
+.rpo-outcome-layout{
+  display:grid;
+  grid-template-columns:minmax(0,1.28fr) minmax(330px,.72fr);
+  gap:74px;
+  align-items:stretch;
+}
+
+.rpo-outcome-grid{
+  display:grid;
+  grid-template-columns:repeat(3,minmax(0,1fr));
+  border:1px solid var(--line);
+}
+
+.rpo-outcome-card{
+  min-height:330px;
+  padding:32px 29px 30px;
+  border-right:1px solid var(--line);
+  background:#080b0f;
+}
+
+.rpo-outcome-card:last-child{border-right:0}
+
+.rpo-outcome-card ul{
+  margin:24px 0 0;
+  padding:20px 0 0 18px;
+  border-top:1px solid rgba(255,255,255,.07);
+}
+
+.rpo-outcome-card li{
+  margin:0 0 9px;
+  padding-left:3px;
+  color:#858f92;
+  font-size:.8rem;
+  line-height:1.68;
+}
+
+.rpo-authority-panel{
+  display:flex;
+  min-height:100%;
+  flex-direction:column;
+  justify-content:space-between;
+  padding:37px 35px;
+  border:1px solid rgba(196,154,88,.28);
+  background:
+    radial-gradient(540px 350px at 100% 0,rgba(196,154,88,.10),transparent 68%),
+    #05080b;
+}
+
+.rpo-authority-panel h3{
+  max-width:430px;
+  margin:18px 0 22px;
+  color:#ece8df;
+  font:500 clamp(1.55rem,2.3vw,2.35rem)/1.2 Orbitron,Montserrat,sans-serif;
+  letter-spacing:-.02em;
+  text-transform:uppercase;
+}
+
+.rpo-authority-panel p{
+  margin:0;
+  color:var(--soft);
+  font-size:.92rem;
+  line-height:1.86;
+}
+
+.rpo-authority-panel .rpo-actions{
+  margin-top:34px;
+  gap:14px;
+}
+
+.rpo-authority-panel .btn{
+  width:100%;
+  min-height:48px;
+  border-radius:0;
+}
+
+.rpo-authority-note{
+  margin:23px 0 0;
+  padding:18px 20px;
+  border-left:2px solid var(--gold);
+  background:rgba(196,154,88,.055);
+  color:#a7afaf;
+  font-size:.82rem;
+  line-height:1.75;
+}
+
+.rpo-authority-home .architecture-line{
+  border-top:1px solid var(--line);
+}
+
+@media(min-width:821px){
+  .rpo-authority-home .definition-copy>p,
+  .rpo-authority-home .anatomy-grid p,
+  .rpo-authority-home .path-grid p,
+  .rpo-authority-home .authority-heading>p,
+  .rpo-authority-home .rpo-flow-card p,
+  .rpo-authority-home .rpo-flow-card strong,
+  .rpo-authority-home .rpo-outcome-card p,
+  .rpo-authority-home .rpo-outcome-card li,
+  .rpo-authority-home .rpo-authority-panel p,
+  .rpo-authority-home .rpo-authority-note{
+    text-align:justify;
+    text-align-last:left;
+    text-justify:inter-word;
+    hyphens:auto;
+    -webkit-hyphens:auto;
+  }
+}
+
+@media(max-width:1120px){
+  .rpo-flow-grid{grid-template-columns:repeat(2,1fr)}
+  .rpo-flow-card:nth-child(2){border-right:0}
+  .rpo-flow-card{border-bottom:1px solid var(--line)}
+  .rpo-flow-card:nth-last-child(-n+2){border-bottom:0}
+  .rpo-flow-card:nth-child(2)::after{display:none}
+  .rpo-flow-card:nth-child(3)::before{
+    position:absolute;
+    top:-13px;
+    left:50%;
+    z-index:3;
+    display:grid;
+    width:26px;
+    height:26px;
+    place-items:center;
+    border:1px solid rgba(196,154,88,.42);
+    background:#080b0f;
+    color:var(--gold);
+    font:500 .75rem Orbitron,Montserrat,sans-serif;
+    transform:translateX(-50%) rotate(90deg);
+    content:"→";
+  }
+  .rpo-outcome-layout{grid-template-columns:1fr}
+  .rpo-authority-panel{min-height:430px}
+}
+
+@media(max-width:920px){
+  .rpo-authority-home .authority-heading{grid-template-columns:1fr;gap:30px}
+  .rpo-outcome-grid{grid-template-columns:1fr}
+  .rpo-outcome-card{min-height:auto;border-right:0;border-bottom:1px solid var(--line)}
+  .rpo-outcome-card:last-child{border-bottom:0}
+}
+
+@media(max-width:720px){
+  .rpo-flow,.rpo-outcomes{padding:75px 0}
+  .rpo-authority-home .authority-heading h2{font-size:clamp(2rem,10vw,3.15rem)}
+  .rpo-flow-grid{grid-template-columns:1fr}
+  .rpo-flow-card{min-height:auto;border-right:0;border-bottom:1px solid var(--line)}
+  .rpo-flow-card:last-child{border-bottom:0}
+  .rpo-flow-card::after,.rpo-flow-card:nth-child(3)::before{display:none!important}
+  .rpo-authority-panel{min-height:auto;padding:30px 26px}
+}

--- a/docs/assets/rpo-home-authority.css
+++ b/docs/assets/rpo-home-authority.css
@@ -22,6 +22,20 @@
   color:var(--pale);
 }
 
+/* Static navigation is visible and stable before JavaScript enhances the dropdown. */
+.rpo-authority-home .truthx-nav{position:relative;display:flex;align-items:center;gap:3px}
+.rpo-authority-home .truthx-nav-main{white-space:nowrap}
+.rpo-authority-home .truthx-nav-toggle{border:0;background:transparent;color:var(--muted);padding:5px 3px;cursor:pointer;font:600 .74rem Montserrat,sans-serif}
+.rpo-authority-home .truthx-nav:hover .truthx-nav-toggle,
+.rpo-authority-home .truthx-nav:focus-within .truthx-nav-toggle,
+.rpo-authority-home .truthx-nav.is-open .truthx-nav-toggle{color:var(--pale)}
+.rpo-authority-home .truthx-nav-menu{position:absolute;left:-14px;top:calc(100% + 14px);z-index:30;display:none;min-width:238px;padding:10px;border:1px solid var(--line);border-radius:14px;background:rgba(5,8,14,.98);box-shadow:0 22px 60px rgba(0,0,0,.48);backdrop-filter:blur(18px)}
+.rpo-authority-home .truthx-nav-menu::before{content:"";position:absolute;left:0;right:0;top:-16px;height:16px}
+.rpo-authority-home .truthx-nav-menu a{display:block;padding:9px 10px;border-radius:9px;white-space:nowrap;text-transform:none!important;letter-spacing:.02em!important;font-size:.76rem!important}
+.rpo-authority-home .truthx-nav-menu a:hover,
+.rpo-authority-home .truthx-nav-menu a:focus{background:rgba(212,175,55,.09);color:var(--pale)}
+.rpo-authority-home .truthx-nav.is-open .truthx-nav-menu{display:grid}
+
 .rpo-flow,
 .rpo-outcomes{
   position:relative;
@@ -216,6 +230,11 @@
   border-top:1px solid var(--line);
 }
 
+@media(min-width:881px){
+  .rpo-authority-home .truthx-nav:hover .truthx-nav-menu,
+  .rpo-authority-home .truthx-nav:focus-within .truthx-nav-menu{display:grid}
+}
+
 @media(min-width:821px){
   .rpo-authority-home .definition-copy>p,
   .rpo-authority-home .anatomy-grid p,
@@ -266,6 +285,15 @@
   .rpo-outcome-grid{grid-template-columns:1fr}
   .rpo-outcome-card{min-height:auto;border-right:0;border-bottom:1px solid var(--line)}
   .rpo-outcome-card:last-child{border-bottom:0}
+}
+
+@media(max-width:880px){
+  .rpo-authority-home .truthx-nav{width:100%;display:grid;grid-template-columns:1fr auto;gap:0}
+  .rpo-authority-home .truthx-nav-main{padding:6px 0}
+  .rpo-authority-home .truthx-nav-toggle{padding:7px 10px}
+  .rpo-authority-home .truthx-nav-menu{position:static;grid-column:1/-1;min-width:0;width:100%;margin-top:4px;padding:7px;box-shadow:none;background:rgba(255,255,255,.025)}
+  .rpo-authority-home .truthx-nav-menu::before{display:none}
+  .rpo-authority-home .truthx-nav-menu a{padding:8px 10px}
 }
 
 @media(max-width:720px){

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>Registered Probative Object (RPO) — Spécification publique | OpenProof</title>
-  <meta name="description" content="Spécification publique du Registered Probative Object (RPO) : noyau scellé, provenance des preuves, réserves explicites et intégrité SHA-256 vérifiable indépendamment.">
+  <title>RPO OpenProof — Objet probatoire enregistré et vérifiable</title>
+  <meta name="description" content="OpenProof définit le RPO, un objet probatoire enregistré qui relie sources, réserves et empreinte SHA-256 pour rendre un dossier traçable et vérifiable indépendamment.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/fr/">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/">
@@ -13,23 +13,50 @@
   <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="Registered Probative Object (RPO) — Spécification publique">
-  <meta property="og:description" content="Spécification publique du Registered Probative Object (RPO) : noyau scellé, provenance des preuves, réserves explicites et intégrité SHA-256 vérifiable indépendamment.">
+  <meta property="og:title" content="RPO OpenProof — Objet probatoire enregistré et vérifiable">
+  <meta property="og:description" content="Un objet probatoire enregistré qui relie sources, réserves et empreinte SHA-256 dans un dossier traçable et vérifiable indépendamment.">
   <meta property="og:url" content="https://rpo.openproof.net/fr/">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="fr_FR">
+  <meta property="og:locale:alternate" content="en_US">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Registered Probative Object (RPO) — Spécification publique">
-  <meta name="twitter:description" content="Spécification publique du Registered Probative Object (RPO) : noyau scellé, provenance des preuves, réserves explicites et intégrité SHA-256 vérifiable indépendamment.">
+  <meta name="twitter:title" content="RPO OpenProof — Objet probatoire enregistré et vérifiable">
+  <meta name="twitter:description" content="Un objet probatoire enregistré qui relie sources, réserves et empreinte SHA-256 dans un dossier traçable et vérifiable indépendamment.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@graph": [
       {
+        "@type": "Organization",
+        "@id": "https://openproof.net/#organization",
+        "name": "OpenProof",
+        "url": "https://openproof.net",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://rpo.openproof.net/assets/openproof-icon.svg"
+        },
+        "description": "Infrastructure probatoire destinée à produire des dossiers traçables, révisables et vérifiables indépendamment.",
+        "founder": { "@id": "https://rpo.openproof.net/fr/gersende-de-parcey.html#person" },
+        "sameAs": [
+          "https://github.com/openproof-net"
+        ]
+      },
+      {
+        "@type": "Person",
+        "@id": "https://rpo.openproof.net/fr/gersende-de-parcey.html#person",
+        "name": "Gersende de Parcey",
+        "url": "https://rpo.openproof.net/fr/gersende-de-parcey.html",
+        "jobTitle": "Fondatrice d’OpenProof et créatrice de TruthX Engine",
+        "sameAs": [
+          "https://www.linkedin.com/in/gryard/"
+        ]
+      },
+      {
         "@type": "WebSite",
         "@id": "https://rpo.openproof.net/fr/#website",
         "url": "https://rpo.openproof.net/fr/",
-        "name": "RPO — Spécification publique",
+        "name": "Spécification publique RPO OpenProof",
         "publisher": { "@id": "https://openproof.net/#organization" },
         "inLanguage": "fr"
       },
@@ -37,19 +64,24 @@
         "@type": "TechArticle",
         "@id": "https://rpo.openproof.net/fr/#specification",
         "headline": "Registered Probative Object (RPO) — Spécification publique v0.1",
-        "description": "Spécification publique d’un objet probatoire stable, traçable et vérifiable indépendamment.",
+        "description": "Spécification publique d’un objet probatoire enregistré conservant la provenance des preuves, les réserves explicites et une intégrité reproductible indépendamment.",
         "url": "https://rpo.openproof.net/fr/",
-        "author": {
-          "@type": "Organization",
-          "name": "OpenProof",
-          "url": "https://openproof.net"
-        },
+        "mainEntityOfPage": { "@id": "https://rpo.openproof.net/fr/" },
+        "image": "https://rpo.openproof.net/images/openproof-cover.png",
+        "datePublished": "2026-07-31",
+        "dateModified": "2026-08-05",
+        "author": { "@id": "https://rpo.openproof.net/fr/gersende-de-parcey.html#person" },
+        "publisher": { "@id": "https://openproof.net/#organization" },
+        "isPartOf": { "@id": "https://rpo.openproof.net/fr/#website" },
         "about": [
-          "Registered Probative Object",
-          "evidence provenance",
-          "canonical JSON",
-          "SHA-256 integrity",
-          "probative infrastructure"
+          "objet probatoire enregistré",
+          "infrastructure probatoire",
+          "provenance des preuves",
+          "traçabilité décisionnelle",
+          "intégrité des preuves numériques",
+          "dossier vérifiable",
+          "JSON canonique",
+          "intégrité SHA-256"
         ],
         "version": "0.1",
         "inLanguage": "fr"
@@ -63,10 +95,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <meta property="og:locale" content="fr_FR">
-  <meta property="og:locale:alternate" content="en_US">
+  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-1">
 </head>
-<body class="rpo-home">
+<body class="rpo-home rpo-authority-home">
   <a class="skip" href="#main">Aller au contenu</a>
 
   <nav class="nav" aria-label="Navigation principale">
@@ -80,6 +111,17 @@
         <a href="/fr/" aria-current="page">Spécification</a>
         <a href="/fr/examples.html">Voir un RPO</a>
         <a href="/fr/tests.html">Vérifier un RPO</a>
+        <div class="truthx-nav" data-truthx-nav>
+          <a class="truthx-nav-main" href="/fr/truthx-engine/">TruthX Engine</a>
+          <button class="truthx-nav-toggle" type="button" aria-expanded="false" aria-label="Ouvrir les sections TruthX Engine">⌄</button>
+          <div class="truthx-nav-menu">
+            <a href="/fr/truthx-engine/#overview">Vue d’ensemble</a>
+            <a href="/fr/truthx-engine/#modes">Deux modes d’intervention</a>
+            <a href="/fr/truthx-engine/#controls">Contrôles d’intégrité</a>
+            <a href="/fr/truthx-engine/#applications">Applications</a>
+            <a href="/fr/truthx-engine/#landscape">Paysage de recherche</a>
+          </div>
+        </div>
         <a href="/fr/gersende-de-parcey.html">Fondatrice</a>
         <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
       </div>
@@ -96,12 +138,13 @@
       <canvas class="stars" aria-hidden="true"></canvas>
       <div class="wrap rpo-hero-grid">
         <div class="rpo-copy">
-          <p class="eyebrow">OPENPROOF · NORME PUBLIQUE · V0.1</p>
-          <h1><span>Un objet probatoire.<br>Stable. Vérifiable. Défendable.</span></h1>
-          <p class="rpo-lead"><span>Le RPO est le format public produit par OpenProof pour préserver un dossier structuré, ses sources, ses réserves et son intégrité — sans confondre vérification et vérité.</span></p>
+          <p class="eyebrow">OPENPROOF · INFRASTRUCTURE PROBATOIRE · RPO V0.1</p>
+          <h1><span>RPO — UN OBJET PROBATOIRE ENREGISTRÉ.<br>STABLE. VÉRIFIABLE. DÉFENDABLE.</span></h1>
+          <p class="rpo-lead"><span>Le RPO est le format public d’OpenProof pour préserver un dossier traçable, ses sources, ses réserves et son intégrité — sans confondre vérification et vérité.</span></p>
           <div class="rpo-actions">
             <a class="btn primary" href="#definition-title"><span>Comprendre le RPO</span></a>
             <a class="btn" href="/fr/examples.html"><span>Voir un RPO</span></a>
+            <a class="rpo-text-link" href="/fr/truthx-engine/">Découvrir TruthX Engine →</a>
           </div>
           <p class="version-line">RPO v0.1 · JSON · SHA-256 · vérification déterministe</p>
         </div>
@@ -129,7 +172,7 @@
         <div class="definition-grid">
           <h2 id="definition-title"><span>Ce que le RPO garantit.<br>Et ce qu’il ne prétend pas garantir.</span></h2>
           <div class="definition-copy">
-            <p>Un RPO rend détectable toute modification du noyau scellé. Il conserve la provenance, les transformations et les réserves nécessaires à un examen indépendant.</p>
+            <p>Un RPO rend détectable toute modification du noyau scellé. Il conserve la provenance des preuves, les transformations et les réserves explicites nécessaires à un examen indépendant.</p>
             <p class="boundary"><span><strong>Limite essentielle :</strong> l’intégrité d’un objet ne prouve pas la vérité de son contenu. OpenProof structure et rend vérifiable ; il ne juge pas.</span></p>
           </div>
         </div>
@@ -149,9 +192,54 @@
       </div>
     </section>
 
+    <section class="rpo-flow" aria-labelledby="flow-title">
+      <div class="wrap">
+        <p class="section-index">03 · DE LA FRAGMENTATION À LA VÉRIFICATION</p>
+        <div class="authority-heading">
+          <h2 id="flow-title">DE LA RÉALITÉ FRAGMENTÉE À UN DOSSIER VÉRIFIABLE.</h2>
+          <p>Le RPO maintient une continuité entre informations, décisions et examen sans obliger tous les professionnels à utiliser le même logiciel métier.</p>
+        </div>
+        <div class="rpo-flow-grid">
+          <article class="rpo-flow-card"><span>01 · FRAGMENTÉ</span><h3>Les sources et décisions sont dispersées</h3><p>Documents, courriels, rapports, déclarations et logiciels de projet détiennent chacun une partie de la situation.</p><strong>Risque : le dossier est reconstitué trop tard, à partir de versions concurrentes.</strong></article>
+          <article class="rpo-flow-card"><span>02 · STRUCTURÉ</span><h3>Un état commun est constitué</h3><p>Sources, acteurs, événements, décisions et références probatoires sont représentés dans une structure stable et lisible par la machine.</p><strong>Résultat : la traçabilité décisionnelle devient inspectable au lieu d’être seulement affirmée.</strong></article>
+          <article class="rpo-flow-card"><span>03 · QUALIFIÉ</span><h3>Les limites restent explicites</h3><p>Contradictions, pièces manquantes, réserves et points non résolus demeurent visibles au lieu d’être masqués par un récit trop affirmatif.</p><strong>Résultat : un dossier prêt pour l’audit ne prétend pas être dépourvu d’incertitudes.</strong></article>
+          <article class="rpo-flow-card"><span>04 · VÉRIFIABLE</span><h3>Chaque copie devient comparable</h3><p>Une représentation déterministe et une empreinte SHA-256 rendent l’altération silencieuse détectable et l’examen indépendant reproductible.</p><strong>Résultat : l’intégrité des preuves numériques peut être contrôlée sans faire confiance à OpenProof.</strong></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="rpo-outcomes" aria-labelledby="outcomes-title">
+      <div class="wrap">
+        <p class="section-index">04 · VALEUR PRATIQUE</p>
+        <div class="authority-heading">
+          <h2 id="outcomes-title">QU’EST-CE QUI CHANGE LORSQU’UN DOSSIER RESTE DÉMONTRABLE ?</h2>
+          <p>Le même RPO peut servir à corriger plus tôt, auditer, assurer, médier ou préparer un travail juridique sans prétendre que tous ces métiers se confondent.</p>
+        </div>
+        <div class="rpo-outcome-layout">
+          <div class="rpo-outcome-grid">
+            <article class="rpo-outcome-card"><span>01 · DÉCISION CONTESTÉE</span><h3>Reconstituer ce qui était connu</h3><p>Retrouver les informations, réserves et états enregistrés disponibles au moment où la décision a été prise.</p><ul><li>Reconstruction de décision</li><li>Provenance des preuves</li><li>Revue de gouvernance</li></ul></article>
+            <article class="rpo-outcome-card"><span>02 · PROJET EN COURS</span><h3>Détecter l’écart plus tôt</h3><p>Comparer ce qui était attendu, déclaré et démontré pendant qu’une correction reste encore possible.</p><ul><li>Traçabilité des décisions de projet</li><li>Intégrité de livraison</li><li>Défauts et remédiation</li></ul></article>
+            <article class="rpo-outcome-card"><span>03 · EXAMEN OU CONFLIT</span><h3>Partager un état révisable</h3><p>Donner aux auditeurs, assureurs, médiateurs ou juristes un dossier stable dont les limites restent explicites.</p><ul><li>Dossier prêt pour l’audit</li><li>Revue probatoire d’assurance</li><li>Reconstruction de preuves juridiques</li></ul></article>
+          </div>
+          <aside class="rpo-authority-panel">
+            <div>
+              <p class="section-index">LE MOTEUR DERRIÈRE L’OBJET</p>
+              <h3>TruthX Engine structure. OpenProof conserve. Le RPO enregistre.</h3>
+              <p>TruthX Engine est le moteur déterministe qui relie sources, attentes, décisions, contradictions et résultats avant qu’OpenProof n’enregistre le résultat revu sous la forme d’un RPO vérifiable.</p>
+              <p class="rpo-authority-note">OpenProof est l’infrastructure probatoire. TruthX Engine est le moteur de structuration déterministe qui l’alimente. Le RPO est l’objet probatoire enregistré qu’il produit.</p>
+            </div>
+            <div class="rpo-actions">
+              <a class="btn primary" href="/fr/truthx-engine/">Découvrir TruthX Engine</a>
+              <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
     <section class="rpo-paths" aria-labelledby="paths-title">
       <div class="wrap">
-        <p class="section-index">03 · ACCÈS PUBLIC</p>
+        <p class="section-index">05 · ACCÈS PUBLIC</p>
         <h2 id="paths-title"><span>Comprendre. Voir. Vérifier.</span></h2>
         <div class="path-grid">
           <a href="#definition-title">
@@ -193,11 +281,12 @@
       <div class="footer-links">
         <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
         <a href="/fr/">Spécification</a>
+        <a href="/fr/truthx-engine/">TruthX Engine</a>
         <a href="https://openproof.net">OpenProof</a>
-        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende Ryard de Parcey sur LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
+        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey sur LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
       </div>
     </div>
   </footer>
-  <script src="/assets/openproof-v2.js?v=20260805-6"></script>
+  <script src="/assets/openproof-v2.js?v=20260805-7"></script>
 </body>
 </html>

--- a/docs/how-it-works.html
+++ b/docs/how-it-works.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="robots" content="noindex,follow">
-  <meta http-equiv="refresh" content="0; url=https://rpo.openproof.net/spec.html">
-  <link rel="canonical" href="https://rpo.openproof.net/spec.html">
+  <meta http-equiv="refresh" content="0; url=https://rpo.openproof.net/">
+  <link rel="canonical" href="https://rpo.openproof.net/">
   <title>Moved · OpenProof RPO</title>
-  <script>window.location.replace("https://rpo.openproof.net/spec.html");</script>
+  <script>window.location.replace("https://rpo.openproof.net/");</script>
 </head>
 <body>
-  <p>This page has moved to <a href="https://rpo.openproof.net/spec.html">the RPO Specification</a>.</p>
+  <p>This page has moved to <a href="https://rpo.openproof.net/">the canonical RPO public specification</a>.</p>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="theme-color" content="#050809">
-  <title>Registered Probative Object (RPO) — Public Specification | OpenProof</title>
-  <meta name="description" content="Public specification of the Registered Probative Object (RPO): sealed core, evidence provenance, explicit reservations and independently verifiable SHA-256 integrity.">
+  <title>OpenProof RPO — Registered Probative Object &amp; Verifiable Evidence</title>
+  <meta name="description" content="OpenProof defines the RPO, a registered probative object linking sources, reservations and a SHA-256 fingerprint into a traceable, independently verifiable record.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://rpo.openproof.net/">
   <link rel="alternate" hreflang="en" href="https://rpo.openproof.net/">
@@ -13,23 +13,50 @@
   <link rel="alternate" hreflang="x-default" href="https://rpo.openproof.net/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="OpenProof">
-  <meta property="og:title" content="Registered Probative Object (RPO) — Public Specification">
-  <meta property="og:description" content="Public specification of the Registered Probative Object (RPO): sealed core, evidence provenance, explicit reservations and independently verifiable SHA-256 integrity.">
+  <meta property="og:title" content="OpenProof RPO — Registered Probative Object &amp; Verifiable Evidence">
+  <meta property="og:description" content="A registered probative object linking sources, reservations and a SHA-256 fingerprint into a traceable, independently verifiable record.">
   <meta property="og:url" content="https://rpo.openproof.net/">
   <meta property="og:image" content="https://rpo.openproof.net/images/openproof-cover.png">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:locale:alternate" content="fr_FR">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Registered Probative Object (RPO) — Public Specification">
-  <meta name="twitter:description" content="Public specification of the Registered Probative Object (RPO): sealed core, evidence provenance, explicit reservations and independently verifiable SHA-256 integrity.">
+  <meta name="twitter:title" content="OpenProof RPO — Registered Probative Object &amp; Verifiable Evidence">
+  <meta name="twitter:description" content="A registered probative object linking sources, reservations and a SHA-256 fingerprint into a traceable, independently verifiable record.">
   <meta name="twitter:image" content="https://rpo.openproof.net/images/openproof-cover.png">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@graph": [
       {
+        "@type": "Organization",
+        "@id": "https://openproof.net/#organization",
+        "name": "OpenProof",
+        "url": "https://openproof.net",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://rpo.openproof.net/assets/openproof-icon.svg"
+        },
+        "description": "Probative infrastructure for traceable, reviewable and independently verifiable records.",
+        "founder": { "@id": "https://rpo.openproof.net/gersende-de-parcey.html#person" },
+        "sameAs": [
+          "https://github.com/openproof-net"
+        ]
+      },
+      {
+        "@type": "Person",
+        "@id": "https://rpo.openproof.net/gersende-de-parcey.html#person",
+        "name": "Gersende de Parcey",
+        "url": "https://rpo.openproof.net/gersende-de-parcey.html",
+        "jobTitle": "Founder of OpenProof and creator of TruthX Engine",
+        "sameAs": [
+          "https://www.linkedin.com/in/gryard/"
+        ]
+      },
+      {
         "@type": "WebSite",
         "@id": "https://rpo.openproof.net/#website",
         "url": "https://rpo.openproof.net/",
-        "name": "RPO Public Specification",
+        "name": "OpenProof RPO Public Specification",
         "publisher": { "@id": "https://openproof.net/#organization" },
         "inLanguage": "en"
       },
@@ -37,19 +64,24 @@
         "@type": "TechArticle",
         "@id": "https://rpo.openproof.net/#specification",
         "headline": "Registered Probative Object (RPO) Public Specification v0.1",
-        "description": "Public specification for a stable, traceable and independently verifiable probative object.",
+        "description": "Public specification for a registered probative object that preserves evidence provenance, explicit reservations and independently reproducible integrity.",
         "url": "https://rpo.openproof.net/",
-        "author": {
-          "@type": "Organization",
-          "name": "OpenProof",
-          "url": "https://openproof.net"
-        },
+        "mainEntityOfPage": { "@id": "https://rpo.openproof.net/" },
+        "image": "https://rpo.openproof.net/images/openproof-cover.png",
+        "datePublished": "2026-07-31",
+        "dateModified": "2026-08-05",
+        "author": { "@id": "https://rpo.openproof.net/gersende-de-parcey.html#person" },
+        "publisher": { "@id": "https://openproof.net/#organization" },
+        "isPartOf": { "@id": "https://rpo.openproof.net/#website" },
         "about": [
           "Registered Probative Object",
+          "probative infrastructure",
           "evidence provenance",
+          "decision traceability",
+          "digital evidence integrity",
+          "verifiable evidence record",
           "canonical JSON",
-          "SHA-256 integrity",
-          "probative infrastructure"
+          "SHA-256 integrity"
         ],
         "version": "0.1",
         "inLanguage": "en"
@@ -63,10 +95,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:locale:alternate" content="fr_FR">
+  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-1">
 </head>
-<body class="rpo-home">
+<body class="rpo-home rpo-authority-home">
   <a class="skip" href="#main">Skip to content</a>
 
   <nav class="nav" aria-label="Primary navigation">
@@ -80,6 +111,17 @@
         <a href="/" aria-current="page">Specification</a>
         <a href="/examples.html">See an RPO</a>
         <a href="/tests.html">Verify an RPO</a>
+        <div class="truthx-nav" data-truthx-nav>
+          <a class="truthx-nav-main" href="/truthx-engine/">TruthX Engine</a>
+          <button class="truthx-nav-toggle" type="button" aria-expanded="false" aria-label="Open TruthX Engine sections">⌄</button>
+          <div class="truthx-nav-menu">
+            <a href="/truthx-engine/#overview">Overview</a>
+            <a href="/truthx-engine/#modes">Two operating modes</a>
+            <a href="/truthx-engine/#controls">Integrity controls</a>
+            <a href="/truthx-engine/#applications">Applications</a>
+            <a href="/truthx-engine/#landscape">Research landscape</a>
+          </div>
+        </div>
         <a href="/gersende-de-parcey.html">Founder</a>
         <a href="https://openproof.net" class="external-link">OpenProof ↗</a>
       </div>
@@ -96,12 +138,13 @@
       <canvas class="stars" aria-hidden="true"></canvas>
       <div class="wrap rpo-hero-grid">
         <div class="rpo-copy">
-          <p class="eyebrow">OPENPROOF · PUBLIC STANDARD · V0.1</p>
-          <h1><span>One probative object.<br>Stable. Verifiable. Defensible.</span></h1>
-          <p class="rpo-lead"><span>The RPO is the public format produced by OpenProof to preserve a structured record, its sources, reservations and integrity — without confusing verification with truth.</span></p>
+          <p class="eyebrow">OPENPROOF · PROBATIVE INFRASTRUCTURE · RPO V0.1</p>
+          <h1><span>RPO — A REGISTERED PROBATIVE OBJECT.<br>STABLE. VERIFIABLE. DEFENSIBLE.</span></h1>
+          <p class="rpo-lead"><span>The RPO is the public OpenProof format for preserving a traceable record, its sources, reservations and integrity — without confusing verification with truth.</span></p>
           <div class="rpo-actions">
             <a class="btn primary" href="#definition-title"><span>Understand the RPO</span></a>
             <a class="btn" href="/examples.html"><span>See an RPO</span></a>
+            <a class="rpo-text-link" href="/truthx-engine/">Discover TruthX Engine →</a>
           </div>
           <p class="version-line">RPO v0.1 · JSON · SHA-256 · deterministic verification</p>
         </div>
@@ -129,7 +172,7 @@
         <div class="definition-grid">
           <h2 id="definition-title"><span>What the RPO guarantees.<br>And what it does not claim to guarantee.</span></h2>
           <div class="definition-copy">
-            <p>An RPO makes any change to the sealed core detectable. It preserves the provenance, transformations and reservations required for independent review.</p>
+            <p>An RPO makes any change to the sealed core detectable. It preserves evidence provenance, transformations and explicit reservations required for independent review.</p>
             <p class="boundary"><span><strong>Essential boundary:</strong> object integrity does not prove content truth. OpenProof structures and makes records verifiable; it does not adjudicate.</span></p>
           </div>
         </div>
@@ -149,9 +192,54 @@
       </div>
     </section>
 
+    <section class="rpo-flow" aria-labelledby="flow-title">
+      <div class="wrap">
+        <p class="section-index">03 · FROM FRAGMENTATION TO VERIFICATION</p>
+        <div class="authority-heading">
+          <h2 id="flow-title">FROM FRAGMENTED REALITY TO A VERIFIABLE RECORD.</h2>
+          <p>The RPO creates continuity between information, decisions and review without forcing every professional to use the same operational tool.</p>
+        </div>
+        <div class="rpo-flow-grid">
+          <article class="rpo-flow-card"><span>01 · FRAGMENTED</span><h3>Sources and decisions are dispersed</h3><p>Documents, emails, reports, declarations and project systems contain different parts of the situation.</p><strong>Risk: the record is reconstructed too late, from competing versions.</strong></article>
+          <article class="rpo-flow-card"><span>02 · STRUCTURED</span><h3>A common state is created</h3><p>Sources, actors, events, decisions and evidence references are represented in a stable, machine-readable structure.</p><strong>Result: decision traceability becomes inspectable rather than merely asserted.</strong></article>
+          <article class="rpo-flow-card"><span>03 · QUALIFIED</span><h3>Limits remain explicit</h3><p>Contradictions, missing material, reservations and unresolved points remain visible instead of being hidden by a confident narrative.</p><strong>Result: audit-ready does not mean uncertainty-free.</strong></article>
+          <article class="rpo-flow-card"><span>04 · VERIFIABLE</span><h3>Every copy becomes comparable</h3><p>A deterministic representation and SHA-256 fingerprint make silent alteration detectable and independent review reproducible.</p><strong>Result: digital evidence integrity can be checked without trusting OpenProof.</strong></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="rpo-outcomes" aria-labelledby="outcomes-title">
+      <div class="wrap">
+        <p class="section-index">04 · PRACTICAL VALUE</p>
+        <div class="authority-heading">
+          <h2 id="outcomes-title">WHAT CHANGES WHEN A RECORD REMAINS DEMONSTRABLE?</h2>
+          <p>The same RPO can support early correction, independent audit, mediation, insurance review or legal work without pretending that all those professions are the same.</p>
+        </div>
+        <div class="rpo-outcome-layout">
+          <div class="rpo-outcome-grid">
+            <article class="rpo-outcome-card"><span>01 · CONTESTED DECISION</span><h3>Reconstruct what was known</h3><p>Recover the information, reservations and recorded state available when the decision was made.</p><ul><li>Decision reconstruction</li><li>Evidence provenance</li><li>Governance review</li></ul></article>
+            <article class="rpo-outcome-card"><span>02 · ACTIVE PROJECT</span><h3>Detect divergence earlier</h3><p>Compare what was expected, declared and evidenced while the gap can still be corrected.</p><ul><li>Project decision traceability</li><li>Delivery integrity</li><li>Defect and remediation records</li></ul></article>
+            <article class="rpo-outcome-card"><span>03 · REVIEW OR DISPUTE</span><h3>Share one reviewable state</h3><p>Give auditors, insurers, mediators or legal teams a stable record with explicit limits.</p><ul><li>Audit-ready record</li><li>Insurance evidence review</li><li>Legal evidence reconstruction</li></ul></article>
+          </div>
+          <aside class="rpo-authority-panel">
+            <div>
+              <p class="section-index">THE ENGINE BEHIND THE OBJECT</p>
+              <h3>TruthX Engine structures. OpenProof preserves. The RPO records.</h3>
+              <p>TruthX Engine is the deterministic structuring engine that connects sources, expectations, decisions, contradictions and outcomes before OpenProof records the reviewed result as a verifiable RPO.</p>
+              <p class="rpo-authority-note">OpenProof is the probative infrastructure. TruthX Engine is the deterministic structuring engine powering it. RPO is the registered probative object it produces.</p>
+            </div>
+            <div class="rpo-actions">
+              <a class="btn primary" href="/truthx-engine/">Discover TruthX Engine</a>
+              <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualify a case</a>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
     <section class="rpo-paths" aria-labelledby="paths-title">
       <div class="wrap">
-        <p class="section-index">03 · PUBLIC ACCESS</p>
+        <p class="section-index">05 · PUBLIC ACCESS</p>
         <h2 id="paths-title"><span>Understand. See. Verify.</span></h2>
         <div class="path-grid">
           <a href="#definition-title">
@@ -193,11 +281,12 @@
       <div class="footer-links">
         <a href="https://github.com/openproof-net/rpo-spec-v0.1">GitHub</a>
         <a href="/">Specification</a>
+        <a href="/truthx-engine/">TruthX Engine</a>
         <a href="https://openproof.net">OpenProof</a>
-        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende Ryard de Parcey on LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
+        <a class="linkedin-link" href="https://www.linkedin.com/in/gryard/" target="_blank" rel="noopener noreferrer" aria-label="Gersende de Parcey on LinkedIn"><span class="linkedin-glyph" aria-hidden="true">in</span><span>LinkedIn</span></a>
       </div>
     </div>
   </footer>
-  <script src="/assets/openproof-v2.js?v=20260805-6"></script>
+  <script src="/assets/openproof-v2.js?v=20260805-7"></script>
 </body>
 </html>


### PR DESCRIPTION
## Purpose

The RPO homepage already had strong visual authority, but its semantic coverage was narrower than the newer demonstration, verification, TruthX Engine and Founder pages. This PR preserves the validated hero and adds the explanatory depth required for both human comprehension and search discovery.

## Homepage changes

- preserves the existing orbital RPO hero and canonical OpenProof charter;
- makes the visible H1 explicitly name the `Registered Probative Object` / `objet probatoire enregistré`;
- adds a direct TruthX Engine CTA in the hero;
- keeps the public journey `Understand / See / Verify` and `Comprendre / Voir / Vérifier`;
- adds a static, crawlable TruthX Engine navigation entry while preserving the existing dropdown enhancement.

## New pedagogical sections

### From fragmented reality to a verifiable record

Explains the transition from dispersed sources and decisions to:

1. a shared structured state;
2. explicit reservations and unresolved points;
3. a deterministic representation;
4. a reproducible SHA-256 fingerprint.

### What changes in practice

Shows the concrete value for:

- contested decisions;
- active projects and delivery integrity;
- audit, insurance, mediation and legal evidence reconstruction.

A dedicated panel connects the architecture explicitly:

> OpenProof is the probative infrastructure. TruthX Engine is the deterministic structuring engine powering it. RPO is the registered probative object it produces.

## SEO and structured data

- rewrites FR/EN title tags and meta descriptions around the real category and user problem;
- adds naturally distributed terms such as decision traceability, evidence provenance, digital evidence integrity, dossier vérifiable and audit-ready record;
- expands JSON-LD with complete `Organization`, `Person`, `WebSite` and `TechArticle` nodes;
- adds author, publisher, image, publication and modification dates, main entity and topic coverage;
- keeps canonical, `hreflang`, Open Graph and social metadata aligned;
- justifies substantive editorial copy on desktop without justifying labels, technical values or controls.

## Technical cleanup

- redirects the legacy `how-it-works.html` route directly to the canonical homepage instead of creating a redirect chain;
- keeps all new content responsive and page-scoped;
- does not change TruthX Engine code, private deterministic rules, the RPO schema or the public verification mechanism.

## Remaining external step

Google Search Console resubmission and URL inspection are not performed by this repository change. The canonical pages and sitemap are ready for that follow-up once Search Console access is available.
