### PR TITLE
Replace RPO homepage cards with TruthX-style system diagrams

### DIFF
--- a/docs/assets/.branch-setup-final
+++ b/docs/assets/.branch-setup-final
@@ -1,1 +1,0 @@
-temporary

--- a/docs/assets/.cleanup-note
+++ b/docs/assets/.cleanup-note
@@ -1,1 +1,0 @@
-temporary

--- a/docs/assets/.final-temp-marker
+++ b/docs/assets/.final-temp-marker
@@ -1,1 +1,0 @@
-temporary

--- a/docs/assets/.ignore-this-marker
+++ b/docs/assets/.ignore-this-marker
@@ -1,1 +1,0 @@
-temporary marker

--- a/docs/assets/.rpo-home-diagram-redesign-branch-marker
+++ b/docs/assets/.rpo-home-diagram-redesign-branch-marker
@@ -1,1 +1,0 @@
-branch marker

--- a/docs/assets/rpo-home-diagrams.css
+++ b/docs/assets/rpo-home-diagrams.css
@@ -1,1 +1,496 @@
-placeholder
+/*
+ * RPO homepage diagram layer
+ * Replaces two card-heavy sections with system maps inspired by TruthX Engine.
+ */
+
+.rpo-transform-map,
+.rpo-value-map{
+  display:grid;
+  grid-template-columns:minmax(220px,.78fr) 56px minmax(320px,.9fr) 56px minmax(220px,.78fr);
+  gap:18px;
+  align-items:center;
+  margin-top:48px;
+}
+
+.rpo-diagram-label{
+  margin:0 0 18px;
+  color:var(--gold);
+  font:600 .61rem/1.4 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.13em;
+  text-transform:uppercase;
+}
+
+.rpo-diagram-copy{
+  margin:21px 0 0;
+  color:var(--soft);
+  font-size:.86rem;
+  line-height:1.78;
+}
+
+.rpo-map-arrow{
+  position:relative;
+  width:100%;
+  height:1px;
+  background:linear-gradient(90deg,rgba(196,154,88,.12),rgba(196,154,88,.68));
+}
+
+.rpo-map-arrow::before{
+  position:absolute;
+  top:50%;
+  left:0;
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:#c7a65f;
+  box-shadow:0 0 12px rgba(213,175,96,.7);
+  transform:translateY(-50%);
+  content:"";
+}
+
+.rpo-map-arrow::after{
+  position:absolute;
+  top:50%;
+  right:0;
+  width:8px;
+  height:8px;
+  border-top:1px solid #d3b16b;
+  border-right:1px solid #d3b16b;
+  transform:translateY(-50%) rotate(45deg);
+  content:"";
+}
+
+/* 03 — fragmented reality to a verifiable record */
+.rpo-transform-sources,
+.rpo-transform-record{
+  position:relative;
+  z-index:2;
+}
+
+.rpo-source-stack,
+.rpo-record-signals{
+  display:grid;
+  gap:9px;
+}
+
+.rpo-source-stack span,
+.rpo-record-signals span{
+  padding:13px 15px;
+  border:1px solid var(--line);
+  background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96));
+  color:#9da6aa;
+  font-size:.76rem;
+  line-height:1.45;
+}
+
+.rpo-source-stack span:nth-child(2),
+.rpo-record-signals span:nth-child(2){
+  margin-inline:12px;
+  border-color:rgba(196,154,88,.28);
+}
+
+.rpo-transform-orbit,
+.rpo-value-engine{
+  position:relative;
+  display:grid;
+  place-items:center;
+  width:100%;
+  min-height:360px;
+}
+
+.rpo-transform-orbit::before,
+.rpo-value-engine::before{
+  position:absolute;
+  inset:13%;
+  border-radius:50%;
+  background:radial-gradient(circle,rgba(214,179,106,.09),rgba(100,117,128,.05) 30%,transparent 68%);
+  filter:blur(2px);
+  content:"";
+}
+
+.rpo-diagram-ring{
+  position:absolute;
+  top:50%;
+  left:50%;
+  border-radius:50%;
+  transform:translate(-50%,-50%);
+}
+
+.rpo-diagram-ring--a{
+  width:74%;
+  height:74%;
+  border:1px solid rgba(172,154,112,.24);
+  animation:rpoDiagramSpin 34s linear infinite;
+}
+
+.rpo-diagram-ring--b{
+  width:96%;
+  height:96%;
+  border:1px solid rgba(133,150,156,.14);
+  animation:rpoDiagramSpinReverse 28s linear infinite;
+}
+
+.rpo-diagram-ring--a::before{
+  position:absolute;
+  inset:17%;
+  border:1px solid rgba(172,154,112,.13);
+  border-radius:50%;
+  content:"";
+}
+
+.rpo-process-core,
+.rpo-engine-core,
+.rpo-record-core{
+  position:relative;
+  z-index:3;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  border:1px solid #d8bc7b;
+  border-radius:50%;
+  background:radial-gradient(circle at 48% 42%,#283038,#0a0e12 66%);
+  box-shadow:inset 0 0 45px rgba(210,174,96,.14),0 0 70px rgba(177,140,70,.11),0 0 0 12px rgba(185,155,92,.035);
+}
+
+.rpo-process-core{
+  width:164px;
+  height:164px;
+}
+
+.rpo-process-core strong,
+.rpo-engine-core strong,
+.rpo-record-core strong{
+  color:#e2c98e;
+  font:600 .76rem/1.35 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.13em;
+}
+
+.rpo-process-core b{
+  margin:4px 0;
+  color:var(--gold);
+  font:500 1.7rem/1 Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-process-core span,
+.rpo-engine-core span,
+.rpo-record-core span{
+  color:#70797d;
+  font:600 .54rem/1.45 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.15em;
+}
+
+.rpo-orbit-node,
+.rpo-engine-node{
+  position:absolute;
+  z-index:4;
+  padding-left:12px;
+  color:#70797d;
+  font:600 7px/1.45 Orbitron,Montserrat,sans-serif;
+  letter-spacing:1.2px;
+  white-space:nowrap;
+  text-transform:uppercase;
+}
+
+.rpo-orbit-node::before,
+.rpo-engine-node::before{
+  position:absolute;
+  top:50%;
+  left:0;
+  width:5px;
+  height:5px;
+  border-radius:50%;
+  background:#c7a65f;
+  box-shadow:0 0 10px #d5af60;
+  transform:translateY(-50%);
+  content:"";
+}
+
+.rpo-orbit-node--structured{top:14%;left:50%;transform:translateX(-50%)}
+.rpo-orbit-node--qualified{right:1%;bottom:21%}
+
+.rpo-transform-record{
+  display:grid;
+  justify-items:center;
+}
+
+.rpo-transform-record .rpo-diagram-label{
+  justify-self:start;
+}
+
+.rpo-record-core{
+  width:176px;
+  height:176px;
+  margin:2px 0 23px;
+}
+
+.rpo-record-core img{
+  width:38px;
+  height:38px;
+  margin-bottom:7px;
+}
+
+.rpo-record-signals{
+  width:100%;
+}
+
+.rpo-transform-rail{
+  position:relative;
+  display:grid;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  margin:58px 0 0;
+  padding:0;
+  border-top:1px solid var(--line);
+  list-style:none;
+}
+
+.rpo-transform-rail li{
+  position:relative;
+  display:grid;
+  grid-template-columns:34px 1fr;
+  gap:13px;
+  min-height:210px;
+  padding:29px 25px 0;
+  border-right:1px solid var(--line);
+}
+
+.rpo-transform-rail li:last-child{border-right:0}
+
+.rpo-transform-rail li::before{
+  position:absolute;
+  top:-4px;
+  left:25px;
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  background:#c7a65f;
+  box-shadow:0 0 12px rgba(213,175,96,.7);
+  content:"";
+}
+
+.rpo-transform-rail>li>span{
+  color:var(--gold);
+  font:600 .66rem/1.5 Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-transform-rail strong{
+  display:block;
+  color:var(--pale);
+  font:600 .9rem/1.45 Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-transform-rail p{
+  margin:13px 0 0;
+  color:var(--soft);
+  font-size:.82rem;
+  line-height:1.72;
+}
+
+.rpo-transform-rail small{
+  display:block;
+  margin-top:16px;
+  padding-top:14px;
+  border-top:1px solid rgba(255,255,255,.07);
+  color:#858f92;
+  font-size:.72rem;
+  line-height:1.65;
+}
+
+/* 04 — professional situations converging on one integrity engine */
+.rpo-value-map{
+  grid-template-columns:minmax(270px,.9fr) 56px minmax(330px,.9fr) 56px minmax(250px,.72fr);
+  align-items:center;
+}
+
+.rpo-value-inputs{
+  display:grid;
+  gap:13px;
+}
+
+.rpo-value-node{
+  position:relative;
+  padding:20px 22px 19px 24px;
+  border-left:1px solid rgba(196,154,88,.55);
+  background:linear-gradient(90deg,rgba(196,154,88,.06),rgba(8,11,15,.82) 54%,transparent);
+}
+
+.rpo-value-node::after{
+  position:absolute;
+  top:50%;
+  right:-24px;
+  width:24px;
+  height:1px;
+  background:linear-gradient(90deg,rgba(196,154,88,.5),transparent);
+  content:"";
+}
+
+.rpo-value-node>span{
+  color:var(--gold);
+  font:600 .59rem/1.4 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+}
+
+.rpo-value-node h3{
+  margin:11px 0 10px;
+  color:var(--pale);
+  font:600 .91rem/1.42 Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-value-node p{
+  margin:0;
+  color:var(--soft);
+  font-size:.82rem;
+  line-height:1.72;
+}
+
+.rpo-value-node small{
+  display:block;
+  margin-top:13px;
+  padding-top:11px;
+  border-top:1px solid rgba(255,255,255,.07);
+  color:#7f898d;
+  font-size:.68rem;
+  line-height:1.55;
+}
+
+.rpo-engine-core{
+  width:190px;
+  height:190px;
+}
+
+.rpo-engine-core img{
+  width:42px;
+  height:42px;
+  margin-bottom:10px;
+}
+
+.rpo-engine-node--sources{top:13%;left:50%;transform:translateX(-50%)}
+.rpo-engine-node--decisions{top:36%;right:-1%}
+.rpo-engine-node--gaps{bottom:17%;right:8%}
+.rpo-engine-node--outcomes{bottom:17%;left:8%}
+.rpo-engine-node--expectations{top:36%;left:-1%}
+
+.rpo-probative-chain{
+  display:grid;
+}
+
+.rpo-chain-step{
+  padding:20px 21px;
+  border:1px solid var(--line);
+  background:linear-gradient(180deg,rgba(13,19,25,.94),rgba(5,8,11,.96));
+}
+
+.rpo-chain-step span{
+  color:var(--gold);
+  font:600 .59rem/1.4 Orbitron,Montserrat,sans-serif;
+  letter-spacing:.13em;
+}
+
+.rpo-chain-step strong{
+  display:block;
+  margin-top:9px;
+  color:var(--pale);
+  font:600 1rem/1.4 Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-chain-step p{
+  margin:10px 0 0;
+  color:var(--soft);
+  font-size:.79rem;
+  line-height:1.68;
+}
+
+.rpo-chain-arrow{
+  display:grid;
+  min-height:38px;
+  place-items:center;
+  color:var(--gold);
+  font:500 1.1rem Orbitron,Montserrat,sans-serif;
+}
+
+.rpo-probative-chain .rpo-authority-note{
+  margin-top:18px;
+}
+
+.rpo-probative-chain .rpo-actions{
+  display:grid;
+  gap:10px;
+  margin-top:18px;
+}
+
+.rpo-probative-chain .btn{
+  width:100%;
+  min-height:46px;
+  border-radius:0;
+}
+
+@media(min-width:821px){
+  .rpo-diagram-copy,
+  .rpo-transform-rail p,
+  .rpo-transform-rail small,
+  .rpo-value-node p,
+  .rpo-value-node small,
+  .rpo-chain-step p{
+    text-align:justify;
+    text-align-last:left;
+    text-justify:inter-word;
+    hyphens:auto;
+    -webkit-hyphens:auto;
+  }
+}
+
+@media(max-width:1120px){
+  .rpo-transform-map,
+  .rpo-value-map{
+    grid-template-columns:1fr;
+    gap:24px;
+  }
+  .rpo-map-arrow{
+    width:1px;
+    height:42px;
+    margin:auto;
+    background:linear-gradient(180deg,rgba(196,154,88,.12),rgba(196,154,88,.68));
+  }
+  .rpo-map-arrow::before{top:0;left:50%;transform:translateX(-50%)}
+  .rpo-map-arrow::after{top:auto;right:auto;bottom:0;left:50%;transform:translateX(-50%) rotate(135deg)}
+  .rpo-transform-sources,
+  .rpo-transform-record,
+  .rpo-value-inputs,
+  .rpo-probative-chain{width:min(620px,100%);margin:auto}
+  .rpo-transform-orbit,
+  .rpo-value-engine{width:min(430px,100%);margin:auto}
+  .rpo-transform-rail{grid-template-columns:repeat(2,1fr)}
+  .rpo-transform-rail li:nth-child(2){border-right:0}
+  .rpo-transform-rail li:nth-child(-n+2){border-bottom:1px solid var(--line)}
+  .rpo-value-node::after{display:none}
+}
+
+@media(max-width:720px){
+  .rpo-transform-rail{grid-template-columns:1fr}
+  .rpo-transform-rail li{
+    min-height:auto;
+    padding:27px 0 27px 22px;
+    border-right:0;
+    border-bottom:1px solid var(--line);
+  }
+  .rpo-transform-rail li:last-child{border-bottom:0}
+  .rpo-transform-rail li::before{left:0}
+  .rpo-transform-orbit,
+  .rpo-value-engine{min-height:330px}
+  .rpo-process-core{width:148px;height:148px}
+  .rpo-engine-core{width:170px;height:170px}
+  .rpo-record-core{width:158px;height:158px}
+}
+
+@media(prefers-reduced-motion:reduce){
+  .rpo-diagram-ring{animation:none!important}
+}
+
+@keyframes rpoDiagramSpin{
+  to{transform:translate(-50%,-50%) rotate(360deg)}
+}
+
+@keyframes rpoDiagramSpinReverse{
+  to{transform:translate(-50%,-50%) rotate(-360deg)}
+}

--- a/docs/fr/index.html
+++ b/docs/fr/index.html
@@ -95,7 +95,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-1">
+  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-2">
+  <link rel="stylesheet" href="/assets/rpo-home-diagrams.css?v=20260805-1">
 </head>
 <body class="rpo-home rpo-authority-home">
   <a class="skip" href="#main">Aller au contenu</a>
@@ -192,47 +193,133 @@
       </div>
     </section>
 
-    <section class="rpo-flow" aria-labelledby="flow-title">
+    <section class="rpo-flow rpo-flow-diagram" aria-labelledby="flow-title">
       <div class="wrap">
         <p class="section-index">03 · DE LA FRAGMENTATION À LA VÉRIFICATION</p>
         <div class="authority-heading">
           <h2 id="flow-title">DE LA RÉALITÉ FRAGMENTÉE À UN DOSSIER VÉRIFIABLE.</h2>
           <p>Le RPO maintient une continuité entre informations, décisions et examen sans obliger tous les professionnels à utiliser le même logiciel métier.</p>
         </div>
-        <div class="rpo-flow-grid">
-          <article class="rpo-flow-card"><span>01 · FRAGMENTÉ</span><h3>Les sources et décisions sont dispersées</h3><p>Documents, courriels, rapports, déclarations et logiciels de projet détiennent chacun une partie de la situation.</p><strong>Risque : le dossier est reconstitué trop tard, à partir de versions concurrentes.</strong></article>
-          <article class="rpo-flow-card"><span>02 · STRUCTURÉ</span><h3>Un état commun est constitué</h3><p>Sources, acteurs, événements, décisions et références probatoires sont représentés dans une structure stable et lisible par la machine.</p><strong>Résultat : la traçabilité décisionnelle devient inspectable au lieu d’être seulement affirmée.</strong></article>
-          <article class="rpo-flow-card"><span>03 · QUALIFIÉ</span><h3>Les limites restent explicites</h3><p>Contradictions, pièces manquantes, réserves et points non résolus demeurent visibles au lieu d’être masqués par un récit trop affirmatif.</p><strong>Résultat : un dossier prêt pour l’audit ne prétend pas être dépourvu d’incertitudes.</strong></article>
-          <article class="rpo-flow-card"><span>04 · VÉRIFIABLE</span><h3>Chaque copie devient comparable</h3><p>Une représentation déterministe et une empreinte SHA-256 rendent l’altération silencieuse détectable et l’examen indépendant reproductible.</p><strong>Résultat : l’intégrité des preuves numériques peut être contrôlée sans faire confiance à OpenProof.</strong></article>
+
+        <div class="rpo-transform-map">
+          <div class="rpo-transform-sources">
+            <p class="rpo-diagram-label">01 · RÉALITÉ FRAGMENTÉE</p>
+            <div class="rpo-source-stack">
+              <span>Documents &amp; courriels</span>
+              <span>Rapports &amp; déclarations</span>
+              <span>Décisions &amp; logiciels de projet</span>
+            </div>
+            <p class="rpo-diagram-copy">Des outils et des acteurs différents détiennent chacun une partie de la même situation.</p>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-transform-orbit" aria-label="Structuration et qualification">
+            <div class="rpo-diagram-ring rpo-diagram-ring--a"></div>
+            <div class="rpo-diagram-ring rpo-diagram-ring--b"></div>
+            <div class="rpo-process-core">
+              <strong>STRUCTURER</strong>
+              <b>×</b>
+              <span>QUALIFIER</span>
+            </div>
+            <div class="rpo-orbit-node rpo-orbit-node--structured">02 · ÉTAT COMMUN</div>
+            <div class="rpo-orbit-node rpo-orbit-node--qualified">03 · LIMITES EXPLICITES</div>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-transform-record">
+            <p class="rpo-diagram-label">04 · DOSSIER VÉRIFIABLE</p>
+            <div class="rpo-record-core">
+              <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
+              <strong>RPO</strong>
+              <span>OBJET PROBATOIRE ENREGISTRÉ</span>
+            </div>
+            <div class="rpo-record-signals">
+              <span>Copies comparables</span>
+              <span>Empreinte SHA-256</span>
+              <span>Examen indépendant</span>
+            </div>
+          </div>
         </div>
+
+        <ol class="rpo-transform-rail">
+          <li><span>01</span><div><strong>Fragmenté</strong><p>Documents, courriels, rapports, déclarations et logiciels de projet détiennent différentes parties de la situation.</p><small>Risque : le dossier est reconstitué trop tard, à partir de versions concurrentes.</small></div></li>
+          <li><span>02</span><div><strong>Structuré</strong><p>Sources, acteurs, événements, décisions et références probatoires sont réunis dans un état stable.</p><small>Résultat : la traçabilité décisionnelle devient inspectable au lieu d’être seulement affirmée.</small></div></li>
+          <li><span>03</span><div><strong>Qualifié</strong><p>Contradictions, pièces manquantes, réserves et points non résolus restent visibles.</p><small>Résultat : un dossier prêt pour l’audit ne prétend pas être dépourvu d’incertitudes.</small></div></li>
+          <li><span>04</span><div><strong>Vérifiable</strong><p>Une représentation déterministe rend chaque copie indépendamment comparable.</p><small>Résultat : l’altération silencieuse devient détectable sans faire confiance à OpenProof.</small></div></li>
+        </ol>
       </div>
     </section>
 
-    <section class="rpo-outcomes" aria-labelledby="outcomes-title">
+    <section class="rpo-outcomes rpo-value-diagram" aria-labelledby="outcomes-title">
       <div class="wrap">
         <p class="section-index">04 · VALEUR PRATIQUE</p>
         <div class="authority-heading">
           <h2 id="outcomes-title">QU’EST-CE QUI CHANGE LORSQU’UN DOSSIER RESTE DÉMONTRABLE ?</h2>
           <p>Le même RPO peut servir à corriger plus tôt, auditer, assurer, médier ou préparer un travail juridique sans prétendre que tous ces métiers se confondent.</p>
         </div>
-        <div class="rpo-outcome-layout">
-          <div class="rpo-outcome-grid">
-            <article class="rpo-outcome-card"><span>01 · DÉCISION CONTESTÉE</span><h3>Reconstituer ce qui était connu</h3><p>Retrouver les informations, réserves et états enregistrés disponibles au moment où la décision a été prise.</p><ul><li>Reconstruction de décision</li><li>Provenance des preuves</li><li>Revue de gouvernance</li></ul></article>
-            <article class="rpo-outcome-card"><span>02 · PROJET EN COURS</span><h3>Détecter l’écart plus tôt</h3><p>Comparer ce qui était attendu, déclaré et démontré pendant qu’une correction reste encore possible.</p><ul><li>Traçabilité des décisions de projet</li><li>Intégrité de livraison</li><li>Défauts et remédiation</li></ul></article>
-            <article class="rpo-outcome-card"><span>03 · EXAMEN OU CONFLIT</span><h3>Partager un état révisable</h3><p>Donner aux auditeurs, assureurs, médiateurs ou juristes un dossier stable dont les limites restent explicites.</p><ul><li>Dossier prêt pour l’audit</li><li>Revue probatoire d’assurance</li><li>Reconstruction de preuves juridiques</li></ul></article>
+
+        <div class="rpo-value-map">
+          <div class="rpo-value-inputs">
+            <article class="rpo-value-node">
+              <span>01 · DÉCISION CONTESTÉE</span>
+              <h3>Reconstituer ce qui était connu</h3>
+              <p>Retrouver les informations, réserves et états enregistrés disponibles au moment où la décision a été prise.</p>
+              <small>Reconstruction de décision · Provenance des preuves · Revue de gouvernance</small>
+            </article>
+            <article class="rpo-value-node">
+              <span>02 · PROJET EN COURS</span>
+              <h3>Détecter l’écart plus tôt</h3>
+              <p>Comparer ce qui était attendu, déclaré et démontré pendant qu’une correction reste encore possible.</p>
+              <small>Traçabilité des décisions de projet · Intégrité de livraison · Défauts et remédiation</small>
+            </article>
+            <article class="rpo-value-node">
+              <span>03 · EXAMEN OU CONFLIT</span>
+              <h3>Partager un état révisable</h3>
+              <p>Donner aux auditeurs, assureurs, médiateurs ou juristes un dossier stable dont les limites restent explicites.</p>
+              <small>Dossier prêt pour l’audit · Revue probatoire d’assurance · Reconstruction de preuves juridiques</small>
+            </article>
           </div>
-          <aside class="rpo-authority-panel">
-            <div>
-              <p class="section-index">LE MOTEUR DERRIÈRE L’OBJET</p>
-              <h3>TruthX Engine structure. OpenProof conserve. Le RPO enregistre.</h3>
-              <p>TruthX Engine est le moteur déterministe qui relie sources, attentes, décisions, contradictions et résultats avant qu’OpenProof n’enregistre le résultat revu sous la forme d’un RPO vérifiable.</p>
-              <p class="rpo-authority-note">OpenProof est l’infrastructure probatoire. TruthX Engine est le moteur de structuration déterministe qui l’alimente. Le RPO est l’objet probatoire enregistré qu’il produit.</p>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-value-engine" aria-label="Noyau d’intégrité TruthX Engine">
+            <div class="rpo-diagram-ring rpo-diagram-ring--a"></div>
+            <div class="rpo-diagram-ring rpo-diagram-ring--b"></div>
+            <div class="rpo-engine-core">
+              <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
+              <strong>TRUTHX ENGINE</strong>
+              <span>STRUCTURE</span>
             </div>
+            <div class="rpo-engine-node rpo-engine-node--sources">SOURCES</div>
+            <div class="rpo-engine-node rpo-engine-node--decisions">DÉCISIONS</div>
+            <div class="rpo-engine-node rpo-engine-node--gaps">CONTRADICTIONS</div>
+            <div class="rpo-engine-node rpo-engine-node--outcomes">RÉSULTATS</div>
+            <div class="rpo-engine-node rpo-engine-node--expectations">ATTENTES</div>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-probative-chain">
+            <p class="rpo-diagram-label">LA CHAÎNE PROBATOIRE</p>
+            <article class="rpo-chain-step">
+              <span>OPENPROOF</span>
+              <strong>CONSERVE</strong>
+              <p>La frontière de revue, la provenance et la couche publique de vérification restent distinctes du moteur.</p>
+            </article>
+            <div class="rpo-chain-arrow" aria-hidden="true">↓</div>
+            <article class="rpo-chain-step">
+              <span>RPO</span>
+              <strong>ENREGISTRE</strong>
+              <p>Le résultat revu devient un objet versionné, sourcé et comparable indépendamment.</p>
+            </article>
+            <p class="rpo-authority-note">OpenProof est l’infrastructure probatoire. TruthX Engine est le moteur de structuration déterministe qui l’alimente. Le RPO est l’objet probatoire enregistré qu’il produit.</p>
             <div class="rpo-actions">
               <a class="btn primary" href="/fr/truthx-engine/">Découvrir TruthX Engine</a>
               <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualifier un cas</a>
             </div>
-          </aside>
+          </div>
         </div>
       </div>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,7 +95,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&amp;family=Orbitron:wght@500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/openproof-v2.css?v=20260731-3">
-  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-1">
+  <link rel="stylesheet" href="/assets/rpo-home-authority.css?v=20260805-2">
+  <link rel="stylesheet" href="/assets/rpo-home-diagrams.css?v=20260805-1">
 </head>
 <body class="rpo-home rpo-authority-home">
   <a class="skip" href="#main">Skip to content</a>
@@ -192,47 +193,133 @@
       </div>
     </section>
 
-    <section class="rpo-flow" aria-labelledby="flow-title">
+    <section class="rpo-flow rpo-flow-diagram" aria-labelledby="flow-title">
       <div class="wrap">
         <p class="section-index">03 · FROM FRAGMENTATION TO VERIFICATION</p>
         <div class="authority-heading">
           <h2 id="flow-title">FROM FRAGMENTED REALITY TO A VERIFIABLE RECORD.</h2>
           <p>The RPO creates continuity between information, decisions and review without forcing every professional to use the same operational tool.</p>
         </div>
-        <div class="rpo-flow-grid">
-          <article class="rpo-flow-card"><span>01 · FRAGMENTED</span><h3>Sources and decisions are dispersed</h3><p>Documents, emails, reports, declarations and project systems contain different parts of the situation.</p><strong>Risk: the record is reconstructed too late, from competing versions.</strong></article>
-          <article class="rpo-flow-card"><span>02 · STRUCTURED</span><h3>A common state is created</h3><p>Sources, actors, events, decisions and evidence references are represented in a stable, machine-readable structure.</p><strong>Result: decision traceability becomes inspectable rather than merely asserted.</strong></article>
-          <article class="rpo-flow-card"><span>03 · QUALIFIED</span><h3>Limits remain explicit</h3><p>Contradictions, missing material, reservations and unresolved points remain visible instead of being hidden by a confident narrative.</p><strong>Result: audit-ready does not mean uncertainty-free.</strong></article>
-          <article class="rpo-flow-card"><span>04 · VERIFIABLE</span><h3>Every copy becomes comparable</h3><p>A deterministic representation and SHA-256 fingerprint make silent alteration detectable and independent review reproducible.</p><strong>Result: digital evidence integrity can be checked without trusting OpenProof.</strong></article>
+
+        <div class="rpo-transform-map">
+          <div class="rpo-transform-sources">
+            <p class="rpo-diagram-label">01 · FRAGMENTED REALITY</p>
+            <div class="rpo-source-stack">
+              <span>Documents &amp; email</span>
+              <span>Reports &amp; declarations</span>
+              <span>Decisions &amp; project systems</span>
+            </div>
+            <p class="rpo-diagram-copy">Different tools and actors hold different parts of the same situation.</p>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-transform-orbit" aria-label="Structuring and qualification">
+            <div class="rpo-diagram-ring rpo-diagram-ring--a"></div>
+            <div class="rpo-diagram-ring rpo-diagram-ring--b"></div>
+            <div class="rpo-process-core">
+              <strong>STRUCTURE</strong>
+              <b>×</b>
+              <span>QUALIFY</span>
+            </div>
+            <div class="rpo-orbit-node rpo-orbit-node--structured">02 · COMMON STATE</div>
+            <div class="rpo-orbit-node rpo-orbit-node--qualified">03 · EXPLICIT LIMITS</div>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-transform-record">
+            <p class="rpo-diagram-label">04 · VERIFIABLE RECORD</p>
+            <div class="rpo-record-core">
+              <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
+              <strong>RPO</strong>
+              <span>REGISTERED PROBATIVE OBJECT</span>
+            </div>
+            <div class="rpo-record-signals">
+              <span>Comparable copies</span>
+              <span>SHA-256 fingerprint</span>
+              <span>Independent review</span>
+            </div>
+          </div>
         </div>
+
+        <ol class="rpo-transform-rail">
+          <li><span>01</span><div><strong>Fragmented</strong><p>Documents, emails, reports, declarations and project systems contain different parts of the situation.</p><small>Risk: the record is reconstructed too late, from competing versions.</small></div></li>
+          <li><span>02</span><div><strong>Structured</strong><p>Sources, actors, events, decisions and evidence references are represented in one stable state.</p><small>Result: decision traceability becomes inspectable rather than merely asserted.</small></div></li>
+          <li><span>03</span><div><strong>Qualified</strong><p>Contradictions, missing material, reservations and unresolved points remain visible.</p><small>Result: audit-ready does not mean uncertainty-free.</small></div></li>
+          <li><span>04</span><div><strong>Verifiable</strong><p>A deterministic representation makes every copy independently comparable.</p><small>Result: silent alteration becomes detectable without trusting OpenProof.</small></div></li>
+        </ol>
       </div>
     </section>
 
-    <section class="rpo-outcomes" aria-labelledby="outcomes-title">
+    <section class="rpo-outcomes rpo-value-diagram" aria-labelledby="outcomes-title">
       <div class="wrap">
         <p class="section-index">04 · PRACTICAL VALUE</p>
         <div class="authority-heading">
           <h2 id="outcomes-title">WHAT CHANGES WHEN A RECORD REMAINS DEMONSTRABLE?</h2>
           <p>The same RPO can support early correction, independent audit, mediation, insurance review or legal work without pretending that all those professions are the same.</p>
         </div>
-        <div class="rpo-outcome-layout">
-          <div class="rpo-outcome-grid">
-            <article class="rpo-outcome-card"><span>01 · CONTESTED DECISION</span><h3>Reconstruct what was known</h3><p>Recover the information, reservations and recorded state available when the decision was made.</p><ul><li>Decision reconstruction</li><li>Evidence provenance</li><li>Governance review</li></ul></article>
-            <article class="rpo-outcome-card"><span>02 · ACTIVE PROJECT</span><h3>Detect divergence earlier</h3><p>Compare what was expected, declared and evidenced while the gap can still be corrected.</p><ul><li>Project decision traceability</li><li>Delivery integrity</li><li>Defect and remediation records</li></ul></article>
-            <article class="rpo-outcome-card"><span>03 · REVIEW OR DISPUTE</span><h3>Share one reviewable state</h3><p>Give auditors, insurers, mediators or legal teams a stable record with explicit limits.</p><ul><li>Audit-ready record</li><li>Insurance evidence review</li><li>Legal evidence reconstruction</li></ul></article>
+
+        <div class="rpo-value-map">
+          <div class="rpo-value-inputs">
+            <article class="rpo-value-node">
+              <span>01 · CONTESTED DECISION</span>
+              <h3>Reconstruct what was known</h3>
+              <p>Recover the information, reservations and recorded state available when the decision was made.</p>
+              <small>Decision reconstruction · Evidence provenance · Governance review</small>
+            </article>
+            <article class="rpo-value-node">
+              <span>02 · ACTIVE PROJECT</span>
+              <h3>Detect divergence earlier</h3>
+              <p>Compare what was expected, declared and evidenced while the gap can still be corrected.</p>
+              <small>Project decision traceability · Delivery integrity · Defect and remediation records</small>
+            </article>
+            <article class="rpo-value-node">
+              <span>03 · REVIEW OR DISPUTE</span>
+              <h3>Share one reviewable state</h3>
+              <p>Give auditors, insurers, mediators or legal teams a stable record with explicit limits.</p>
+              <small>Audit-ready record · Insurance evidence review · Legal evidence reconstruction</small>
+            </article>
           </div>
-          <aside class="rpo-authority-panel">
-            <div>
-              <p class="section-index">THE ENGINE BEHIND THE OBJECT</p>
-              <h3>TruthX Engine structures. OpenProof preserves. The RPO records.</h3>
-              <p>TruthX Engine is the deterministic structuring engine that connects sources, expectations, decisions, contradictions and outcomes before OpenProof records the reviewed result as a verifiable RPO.</p>
-              <p class="rpo-authority-note">OpenProof is the probative infrastructure. TruthX Engine is the deterministic structuring engine powering it. RPO is the registered probative object it produces.</p>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-value-engine" aria-label="TruthX Engine integrity core">
+            <div class="rpo-diagram-ring rpo-diagram-ring--a"></div>
+            <div class="rpo-diagram-ring rpo-diagram-ring--b"></div>
+            <div class="rpo-engine-core">
+              <img src="/assets/openproof-icon.svg?v=20260731-2" alt="">
+              <strong>TRUTHX ENGINE</strong>
+              <span>STRUCTURES</span>
             </div>
+            <div class="rpo-engine-node rpo-engine-node--sources">SOURCES</div>
+            <div class="rpo-engine-node rpo-engine-node--decisions">DECISIONS</div>
+            <div class="rpo-engine-node rpo-engine-node--gaps">CONTRADICTIONS</div>
+            <div class="rpo-engine-node rpo-engine-node--outcomes">OUTCOMES</div>
+            <div class="rpo-engine-node rpo-engine-node--expectations">EXPECTATIONS</div>
+          </div>
+
+          <div class="rpo-map-arrow" aria-hidden="true"></div>
+
+          <div class="rpo-probative-chain">
+            <p class="rpo-diagram-label">THE PROBATIVE CHAIN</p>
+            <article class="rpo-chain-step">
+              <span>OPENPROOF</span>
+              <strong>PRESERVES</strong>
+              <p>Review boundaries, provenance and the public verification layer remain distinct from the engine.</p>
+            </article>
+            <div class="rpo-chain-arrow" aria-hidden="true">↓</div>
+            <article class="rpo-chain-step">
+              <span>RPO</span>
+              <strong>RECORDS</strong>
+              <p>The reviewed result becomes a versioned, sourced and independently comparable object.</p>
+            </article>
+            <p class="rpo-authority-note">OpenProof is the probative infrastructure. TruthX Engine is the deterministic structuring engine powering it. RPO is the registered probative object it produces.</p>
             <div class="rpo-actions">
               <a class="btn primary" href="/truthx-engine/">Discover TruthX Engine</a>
               <a class="btn" href="https://app.openproof.net/qualify?intent=case">Qualify a case</a>
             </div>
-          </aside>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Purpose

The two new RPO homepage sections were semantically strong but still read as grids of cards. This redesign keeps all validated copy and SEO coverage while translating the content into the same visual language as the TruthX Engine page: flows, nodes, orbit cores, convergence and explicit outputs.

## Section 03 — From fragmentation to verification

- replaces the four boxed cards with a full transformation map;
- shows fragmented source systems on the left;
- introduces an orbital `Structure × Qualify` core with the intermediate states `Common state` and `Explicit limits`;
- terminates in a visible RPO object with comparable copies, SHA-256 fingerprint and independent review;
- retains the four-step explanation underneath as a restrained rail rather than another card grid;
- preserves all decision-traceability, evidence-provenance, uncertainty and integrity language.

## Section 04 — Practical value

- replaces the three-column use-case table and separate authority panel with one convergence map;
- presents contested decisions, active projects and review/dispute as three entry nodes;
- routes them into an orbital TruthX Engine integrity core;
- makes the downstream chain explicit: `TruthX Engine structures → OpenProof preserves → RPO records`;
- preserves both CTAs and the canonical architecture statement.

## Visual system

- uses warm-metal / steel orbital rings, signal nodes and directional connectors already established on the TruthX Engine page;
- removes the WordPress/table impression without reducing informational depth;
- keeps editorial text justified on desktop;
- includes responsive single-column diagrams for tablet and mobile;
- respects reduced-motion preferences.

## Scope

- English and French homepage only;
- one new page-scoped stylesheet;
- no change to metadata, SEO structure, RPO schema, TruthX Engine logic, verification code or public claims.
