### PR TITLE
Polish RPO homepage diagram typography and convergence

### DIFF
--- a/docs/assets/rpo-home-diagrams.css
+++ b/docs/assets/rpo-home-diagrams.css
@@ -494,3 +494,86 @@
 @keyframes rpoDiagramSpinReverse{
   to{transform:translate(-50%,-50%) rotate(-360deg)}
 }
+
+/* Final micro-polish: premium reading rhythm and explicit three-input convergence. */
+.rpo-transform-rail p{
+  font-size:.88rem;
+  line-height:1.75;
+}
+
+.rpo-transform-rail small{
+  font-size:.77rem;
+  line-height:1.66;
+}
+
+.rpo-value-inputs{
+  position:relative;
+}
+
+@media(min-width:1121px){
+  .rpo-value-inputs{
+    grid-template-rows:repeat(3,minmax(0,1fr));
+  }
+
+  .rpo-value-inputs::before{
+    position:absolute;
+    top:16.666%;
+    right:-18px;
+    bottom:16.666%;
+    width:1px;
+    background:linear-gradient(180deg,rgba(196,154,88,.18),rgba(196,154,88,.58) 50%,rgba(196,154,88,.18));
+    content:"";
+  }
+
+  .rpo-value-node::after{
+    right:-18px;
+    width:18px;
+    background:linear-gradient(90deg,rgba(196,154,88,.54),rgba(196,154,88,.34));
+  }
+
+  .rpo-value-node::before{
+    position:absolute;
+    top:50%;
+    right:-21px;
+    width:6px;
+    height:6px;
+    border-radius:50%;
+    background:#c7a65f;
+    box-shadow:0 0 11px rgba(213,175,96,.64);
+    transform:translateY(-50%);
+    content:"";
+  }
+
+  .rpo-value-node:nth-child(2)::before{
+    display:none;
+  }
+
+  .rpo-value-map>.rpo-map-arrow::before{
+    left:-3px;
+  }
+}
+
+@media(min-width:821px){
+  .rpo-authority-home .authority-heading>p,
+  .rpo-diagram-copy,
+  .rpo-transform-rail p,
+  .rpo-transform-rail small,
+  .rpo-value-node p,
+  .rpo-value-node small,
+  .rpo-chain-step p{
+    text-align:left;
+    text-align-last:auto;
+    text-justify:auto;
+    hyphens:none;
+    -webkit-hyphens:none;
+    word-break:normal;
+    overflow-wrap:normal;
+  }
+}
+
+@media(max-width:1120px){
+  .rpo-value-inputs::before,
+  .rpo-value-node::before{
+    display:none;
+  }
+}


### PR DESCRIPTION
## Purpose

Apply the final approved micro-corrections to the two new RPO homepage diagrams without changing their architecture, copy, SEO or product logic.

## Typography

- disables forced justification and automatic hyphenation inside the narrow explanatory columns;
- keeps body text naturally left-aligned where justification created broken words such as `informa-tion` or `independent-ly`;
- preserves justified editorial text in wider sections;
- increases the lower four-step explanation text slightly for better readability on large screens.

## Practical-value convergence

- adds a subtle vertical steel/gold spine connecting the three use-case entry nodes;
- connects each entry to that spine with a small signal point;
- retains one clear outgoing arrow from the shared junction into TruthX Engine;
- hides this desktop connector treatment in the responsive single-column layout.

## Scope

- one page-scoped CSS file only;
- English and French homepage inherit the same correction;
- no copy, metadata, schema, links, verification code or private engine logic changed.